### PR TITLE
feat: add PnL fields to PerpExecution schema

### DIFF
--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.1.8
+  version: 2.1.9
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.1.8
+  version: 2.1.9
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -532,14 +532,10 @@
         "qty",
         "side",
         "fee",
-        "openingFee",
         "price",
         "type",
         "timestamp",
-        "sequenceNumber",
-        "realizedPnl",
-        "priceVariationPnl",
-        "fundingPnl"
+        "sequenceNumber"
       ],
       "properties": {
         "exchangeId": {
@@ -571,7 +567,7 @@
         },
         "openingFee": {
           "$ref": "#/definitions/SignedDecimal",
-          "description": "Opening fee portion of the total fee in rUSD",
+          "description": "Opening fee portion of the total fee in rUSD. Absent for position-extending executions.",
           "example": "0.25"
         },
         "type": {
@@ -589,17 +585,17 @@
         },
         "realizedPnl": {
           "$ref": "#/definitions/SignedDecimal",
-          "description": "Realized PnL from this execution in rUSD (priceVariationPnl + fundingPnl). Zero for position-extending executions.",
+          "description": "Realized PnL from this execution in rUSD (priceVariationPnl + fundingPnl). Absent for position-extending executions.",
           "example": "12.50"
         },
         "priceVariationPnl": {
           "$ref": "#/definitions/SignedDecimal",
-          "description": "PnL component from price movement in rUSD. Zero for position-extending executions.",
+          "description": "PnL component from price movement in rUSD. Absent for position-extending executions.",
           "example": "15.00"
         },
         "fundingPnl": {
           "$ref": "#/definitions/SignedDecimal",
-          "description": "PnL component from funding payments in rUSD. Zero for position-extending executions.",
+          "description": "PnL component from funding payments in rUSD. Absent for position-extending executions.",
           "example": "-2.50"
         }
       },

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -532,10 +532,14 @@
         "qty",
         "side",
         "fee",
+        "openingFee",
         "price",
         "type",
         "timestamp",
-        "sequenceNumber"
+        "sequenceNumber",
+        "realizedPnl",
+        "priceVariationPnl",
+        "fundingPnl"
       ],
       "properties": {
         "exchangeId": {
@@ -562,7 +566,13 @@
         },
         "fee": {
           "$ref": "#/definitions/SignedDecimal",
+          "description": "Total execution fee in rUSD",
           "example": "0.50"
+        },
+        "openingFee": {
+          "$ref": "#/definitions/SignedDecimal",
+          "description": "Opening fee portion of the total fee in rUSD",
+          "example": "0.25"
         },
         "type": {
           "$ref": "#/definitions/ExecutionType"
@@ -576,6 +586,21 @@
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Execution sequence number, increases by 1 for every perp execution in reya chain",
           "example": 152954
+        },
+        "realizedPnl": {
+          "$ref": "#/definitions/SignedDecimal",
+          "description": "Realized PnL from this execution in rUSD (priceVariationPnl + fundingPnl). Zero for position-extending executions.",
+          "example": "12.50"
+        },
+        "priceVariationPnl": {
+          "$ref": "#/definitions/SignedDecimal",
+          "description": "PnL component from price movement in rUSD. Zero for position-extending executions.",
+          "example": "15.00"
+        },
+        "fundingPnl": {
+          "$ref": "#/definitions/SignedDecimal",
+          "description": "PnL component from funding payments in rUSD. Zero for position-extending executions.",
+          "example": "-2.50"
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
## Summary
- Adds `realizedPnl`, `priceVariationPnl`, `fundingPnl`, and `openingFee` as required fields to `PerpExecution` schema
- These fields enable the UI trade history tab to display per-execution PnL breakdown using V2 endpoints (both REST and WS), replacing the legacy `/api/accounts` polling endpoint
- All fields are `SignedDecimal` type with descriptions

## Context
The UI trade history tab currently relies on a legacy endpoint that computes PnL server-side. Moving to V2 WS+REST requires these fields to be part of the PerpExecution model so they flow through both the REST response and WebSocket snapshots/updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Trading APIs updated to version 2.1.9
  * Perpetual trading execution data now includes detailed fee and profit/loss breakdowns: opening fees, realized P&L, price variation P&L, and funding P&L components, providing traders with enhanced visibility into execution costs and profit/loss composition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->