### PR TITLE
fix: correct startTime/endTime param descriptions

### DIFF
--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.1.9
+  version: 2.1.10
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.1.9
+  version: 2.1.10
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -685,7 +685,7 @@ components:
       name: startTime
       in: query
       required: false
-      description: Return results after this sequence number (for pagination)
+      description: Return results at or after this timestamp, in milliseconds (for pagination)
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733379000
@@ -694,7 +694,7 @@ components:
       name: endTime
       in: query
       required: false
-      description: Return results before this sequence number (for pagination)
+      description: Return results at or before this timestamp, in milliseconds (for pagination)
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000


### PR DESCRIPTION
## Summary

- `StartTimeParam` / `EndTimeParam` descriptions in `openapi-trading-v2.yaml` say _"Return results after/before this sequence number (for pagination)"_, but the underlying handlers filter by `block_timestamp` and expect **millisecond POSIX timestamps** (divided by 1000 to match the seconds-granularity DB column).
- The `PaginationMeta` schema in `trading-schemas.json` already describes them correctly as _"Timestamp of first/last result, in milliseconds"_ — only the request-parameter descriptions were out of sync.
- A customer on Slack flagged the contradiction while trying to fetch the last X hours of perp executions.

## Affected endpoints

All 7 endpoints that reference these shared params:
- `GET /market/{symbol}/perpExecutions`
- `GET /market/{symbol}/spotExecutions`
- `GET /market/{symbol}/spotExecutionBusts`
- `GET /market/{symbol}/candleHistory` (uses `EndTimeParam` only; `getCandles` explicitly errors with `"endTime must be a valid millisecond posix timestamp"`)
- `GET /wallet/{address}/perpExecutions`
- `GET /wallet/{address}/spotExecutions`
- `GET /wallet/{address}/spotExecutionBusts`

## Test plan

- [ ] Visually confirm the rendered docs read "timestamp, in milliseconds" instead of "sequence number"
- [ ] Downstream consumers (reya-off-chain-monorepo `packages/api-v2-sdk`) regenerate cleanly after submodule bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated parameter descriptions for time-based filtering in the trading API to clarify that timestamps are specified in milliseconds.

* **Chores**
  * Version bumped to 2.1.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->