### PR TITLE
feat: add sequenceNumber to SpotExecution schema

### DIFF
--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.1.10
+  version: 2.1.11
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.1.10
+  version: 2.1.11
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -637,7 +637,8 @@
         "fee",
         "price",
         "type",
-        "timestamp"
+        "timestamp",
+        "sequenceNumber"
       ],
       "properties": {
         "exchangeId": {
@@ -688,6 +689,11 @@
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Execution timestamp (milliseconds)",
           "example": 1747927089946
+        },
+        "sequenceNumber": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Execution sequence number, increases by 1 for every spot execution in reya chain",
+          "example": 152954
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
## Summary

- Adds a required `sequenceNumber` field to the `SpotExecution` schema, mirroring `PerpExecution.sequenceNumber` (same `UnsignedInteger` ref, same description style with "perp" → "spot", same example shape).
- Lets API consumers detect gaps in spot execution streams and deterministically order events across REST + WS — capability already available for perp.

## Backwards compatibility

Adding a new required field to a response schema is technically a breaking change. In practice, JSON consumers ignore unknown fields and validators that strictly enforce `required` against responses are uncommon. The symmetric change was previously rolled out for `PerpExecution` without incident.

## Follow-up

A monorepo PR will (1) bump the `specs` submodule pointer to the next release tag (e.g. `2.1.11`) on this PR's merged commit, (2) regenerate `packages/api-v2-sdk` via `scripts/generate-unified-sdk.sh`, and (3) populate `sequenceNumber` in both REST (`transformSpotExecution`) and WS (`convertToSpotExecution`) transformers — the same pattern used today for perp.

## Tagging

The monorepo's `generation-consistency` CI check requires the `specs` submodule pointer to be a **tagged** commit. Once this PR is merged, please push the next `2.1.x` tag onto the merge commit (current latest tag: `2.1.10`) so the monorepo follow-up PR can bump the submodule to that tag.

## Test plan

- [ ] Schema validates: `jq '.definitions.SpotExecution.required | index("sequenceNumber")'` returns a non-null value.
- [ ] `SpotExecution.sequenceNumber` shape diffs only on "perp" vs "spot" wording vs `PerpExecution.sequenceNumber`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API specification versions to 2.1.11 across all trading documentation.

* **New Features**
  * Spot execution records now require a `sequenceNumber` field to track execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->