### PR TITLE
feat: add address to AssetDefinition schema

### DIFF
--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.1.11
+  version: 2.1.12
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.1.11
+  version: 2.1.12
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -968,6 +968,7 @@
       "type": "object",
       "required": [
         "asset",
+        "address",
         "priceHaircut",
         "liquidationDiscount",
         "status",
@@ -978,6 +979,11 @@
         "asset": {
           "$ref": "#/definitions/Asset",
           "example": "WSTETH"
+        },
+        "address": {
+          "$ref": "#/definitions/Address",
+          "description": "ERC20 contract address of the underlying collateral token on the Reya chain.",
+          "example": "0x7ae54d5a9e5a975dfc3261d915f8151dcca76be0"
         },
         "spotMarketSymbol": {
           "$ref": "#/definitions/Symbol"


### PR DESCRIPTION
## Summary
- Adds a required `address` field to `AssetDefinition` (`trading-schemas.json`), typed as `Address`.
- Field exposes the ERC20 contract address of the underlying collateral token on the Reya chain.

## Why
The v1 `/api/trading/collateralConfiguration` endpoint is the only remaining v1 source of collateral token addresses. The UI uses it via `useCollateralAddress` for two on-chain flows (rUSD staking, transfer-between-accounts). With this field on `AssetDefinition`, the UI can switch to `/v2/assetDefinitions` and the v1 endpoint can be deleted.

Addresses are environment-specific, so resolving them server-side keeps the UI chain-agnostic.

## Follow-ups
- Monorepo PR: regenerate api-v2-sdk and populate `address` in `transformCollateralConfig`.
- UI PR (stacked on #1337): swap `useCollateralAddress` to read from `useAssetDefinitions`, delete v1 hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API specification versions to 2.1.12.
  * Asset definition schema now requires an address field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->