### PR TITLE
feat: add sequenceNumber to Order + spotOrderHistory endpoint

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.0
+  version: 2.3.4
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.7
+  version: 2.3.8
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.0
+  version: 2.2.4
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.6
+  version: 2.3.7
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.6
+  version: 2.2.7
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.2
+  version: 2.2.3
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.8
+  version: 2.3.9
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.7
+  version: 2.3.8
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.5
+  version: 2.2.6
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.4
+  version: 2.3.5
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.1
+  version: 2.2.2
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.4
+  version: 2.2.5
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.3
+  version: 2.3.0
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.5
+  version: 2.3.6
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.5
+  version: 2.3.6
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.0
+  version: 2.2.1
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.3
+  version: 2.2.4
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.2
+  version: 2.2.3
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network
@@ -140,7 +140,13 @@ channels:
 
   walletOrderChanges:
     address: /v2/wallet/{address}/orderChanges
-    description: Real-time order change updates for wallet
+    description: |
+      Real-time order change updates for a wallet. The `subscribed` confirmation
+      carries an `OrderChangesSnapshot` payload (current open orders +
+      `snapshotSequenceNumber` cursor). Every subsequent `channel_data`
+      message carries an `Order` with `sequenceNumber` > `snapshotSequenceNumber`,
+      so clients can stitch the live feed onto the `/wallet/{address}/spotOrderHistory`
+      REST endpoint without overlap or gap.
     parameters:
       address:
         description: Ethereum wallet address

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.2
+  version: 2.2.3
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.3
+  version: 2.3.0
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network
@@ -60,17 +60,37 @@ channels:
 
   marketsSummary:
     address: /v2/markets/summary
-    description: Real-time updates for all market summaries
+    description: 'Deprecated: use `/v2/perpMarkets/summary` instead. Real-time updates for all market summaries. This un-prefixed channel still works but will be removed once integrators have migrated to the `perp*` naming. (AsyncAPI 3.0 has no native `deprecated` field on channels; flagged via `x-deprecated`.)'
+    x-deprecated: true
     messages:
       marketsSummaryUpdate:
         $ref: '#/components/messages/MarketsSummaryUpdate'
 
   marketSummary:
     address: /v2/market/{symbol}/summary
-    description: Real-time updates for a specific market's summary
+    description: 'Deprecated: use `/v2/perpMarket/{symbol}/summary` instead. Real-time updates for a specific market''s summary. This un-prefixed channel still works but will be removed once integrators have migrated to the `perp*` naming. (AsyncAPI 3.0 has no native `deprecated` field on channels; flagged via `x-deprecated`.)'
+    x-deprecated: true
     parameters:
       symbol:
         description: Trading symbol (e.g., BTCRUSDPERP, ETHRUSD)
+        location: $message.payload#/symbol
+    messages:
+      marketSummaryUpdate:
+        $ref: '#/components/messages/MarketSummaryUpdate'
+
+  perpMarketsSummary:
+    address: /v2/perpMarkets/summary
+    description: Alias of `/v2/markets/summary` (mirrors `/v2/spotMarkets/summary`). Real-time updates for all perp market summaries
+    messages:
+      marketsSummaryUpdate:
+        $ref: '#/components/messages/MarketsSummaryUpdate'
+
+  perpMarketSummary:
+    address: /v2/perpMarket/{symbol}/summary
+    description: Alias of `/v2/market/{symbol}/summary` (mirrors `/v2/spotMarket/{symbol}/summary`). Real-time updates for a specific perp market's summary
+    parameters:
+      symbol:
+        description: Trading symbol (e.g., BTCRUSDPERP)
         location: $message.payload#/symbol
     messages:
       marketSummaryUpdate:
@@ -294,7 +314,8 @@ operations:
       $ref: '#/channels/marketsSummary'
     messages:
       - $ref: '#/channels/marketsSummary/messages/marketsSummaryUpdate'
-    summary: Receive market summaries updates
+    summary: 'Deprecated: use receivePerpMarketsSummary instead. Receive market summaries updates.'
+    x-deprecated: true
 
   receiveMarketSummary:
     action: receive
@@ -302,7 +323,24 @@ operations:
       $ref: '#/channels/marketSummary'
     messages:
       - $ref: '#/channels/marketSummary/messages/marketSummaryUpdate'
-    summary: Receive specific market summary updates
+    summary: 'Deprecated: use receivePerpMarketSummary instead. Receive specific market summary updates.'
+    x-deprecated: true
+
+  receivePerpMarketsSummary:
+    action: receive
+    channel:
+      $ref: '#/channels/perpMarketsSummary'
+    messages:
+      - $ref: '#/channels/perpMarketsSummary/messages/marketsSummaryUpdate'
+    summary: Receive perp market summaries updates (alias of receiveMarketsSummary)
+
+  receivePerpMarketSummary:
+    action: receive
+    channel:
+      $ref: '#/channels/perpMarketSummary'
+    messages:
+      - $ref: '#/channels/perpMarketSummary/messages/marketSummaryUpdate'
+    summary: Receive specific perp market summary updates (alias of receiveMarketSummary)
 
   receiveSpotMarketsSummary:
     action: receive

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.1
+  version: 2.2.2
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.7
+  version: 2.3.8
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network
@@ -60,17 +60,37 @@ channels:
 
   marketsSummary:
     address: /v2/markets/summary
-    description: Real-time updates for all market summaries
+    description: 'Deprecated: use `/v2/perpMarkets/summary` instead. Real-time updates for all market summaries. This un-prefixed channel still works but will be removed once integrators have migrated to the `perp*` naming. (AsyncAPI 3.0 has no native `deprecated` field on channels; flagged via `x-deprecated`.)'
+    x-deprecated: true
     messages:
       marketsSummaryUpdate:
         $ref: '#/components/messages/MarketsSummaryUpdate'
 
   marketSummary:
     address: /v2/market/{symbol}/summary
-    description: Real-time updates for a specific market's summary
+    description: 'Deprecated: use `/v2/perpMarket/{symbol}/summary` instead. Real-time updates for a specific market''s summary. This un-prefixed channel still works but will be removed once integrators have migrated to the `perp*` naming. (AsyncAPI 3.0 has no native `deprecated` field on channels; flagged via `x-deprecated`.)'
+    x-deprecated: true
     parameters:
       symbol:
         description: Trading symbol (e.g., BTCRUSDPERP, ETHRUSD)
+        location: $message.payload#/symbol
+    messages:
+      marketSummaryUpdate:
+        $ref: '#/components/messages/MarketSummaryUpdate'
+
+  perpMarketsSummary:
+    address: /v2/perpMarkets/summary
+    description: Alias of `/v2/markets/summary` (mirrors `/v2/spotMarkets/summary`). Real-time updates for all perp market summaries
+    messages:
+      marketsSummaryUpdate:
+        $ref: '#/components/messages/MarketsSummaryUpdate'
+
+  perpMarketSummary:
+    address: /v2/perpMarket/{symbol}/summary
+    description: Alias of `/v2/market/{symbol}/summary` (mirrors `/v2/spotMarket/{symbol}/summary`). Real-time updates for a specific perp market's summary
+    parameters:
+      symbol:
+        description: Trading symbol (e.g., BTCRUSDPERP)
         location: $message.payload#/symbol
     messages:
       marketSummaryUpdate:
@@ -306,7 +326,8 @@ operations:
       $ref: '#/channels/marketsSummary'
     messages:
       - $ref: '#/channels/marketsSummary/messages/marketsSummaryUpdate'
-    summary: Receive market summaries updates
+    summary: 'Deprecated: use receivePerpMarketsSummary instead. Receive market summaries updates.'
+    x-deprecated: true
 
   receiveMarketSummary:
     action: receive
@@ -314,7 +335,24 @@ operations:
       $ref: '#/channels/marketSummary'
     messages:
       - $ref: '#/channels/marketSummary/messages/marketSummaryUpdate'
-    summary: Receive specific market summary updates
+    summary: 'Deprecated: use receivePerpMarketSummary instead. Receive specific market summary updates.'
+    x-deprecated: true
+
+  receivePerpMarketsSummary:
+    action: receive
+    channel:
+      $ref: '#/channels/perpMarketsSummary'
+    messages:
+      - $ref: '#/channels/perpMarketsSummary/messages/marketsSummaryUpdate'
+    summary: Receive perp market summaries updates (alias of receiveMarketsSummary)
+
+  receivePerpMarketSummary:
+    action: receive
+    channel:
+      $ref: '#/channels/perpMarketSummary'
+    messages:
+      - $ref: '#/channels/perpMarketSummary/messages/marketSummaryUpdate'
+    summary: Receive specific perp market summary updates (alias of receiveMarketSummary)
 
   receiveSpotMarketsSummary:
     action: receive

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.4
+  version: 2.2.5
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network
@@ -145,7 +145,7 @@ channels:
       carries an `OrderChangesSnapshot` payload (current open orders +
       `snapshotSequenceNumber` cursor). Every subsequent `channel_data`
       message carries an `Order` with `sequenceNumber` > `snapshotSequenceNumber`,
-      so clients can stitch the live feed onto the `/wallet/{address}/spotOrderHistory`
+      so clients can stitch the live feed onto the `/wallet/{address}/orderHistory`
       REST endpoint without overlap or gap.
     parameters:
       address:

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.6
+  version: 2.3.7
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.0
+  version: 2.3.4
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.7
+  version: 2.3.8
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.5
+  version: 2.2.6
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.4
+  version: 2.3.5
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.8
+  version: 2.3.9
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.6
+  version: 2.2.7
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network
@@ -141,17 +141,23 @@ channels:
   walletOrderChanges:
     address: /v2/wallet/{address}/orderChanges
     description: |
-      Real-time order change updates for a wallet. The `subscribed` confirmation
+      Real-time order change updates for a wallet.
+
+      Two server-to-client message types arrive on this logical channel:
+      `orderChangesSubscribed` is the initial `subscribed` confirmation and
       carries an `OrderChangesSnapshot` payload (current open orders +
-      `snapshotSequenceNumber` cursor). Every subsequent `channel_data`
-      message carries an `Order` with `sequenceNumber` > `snapshotSequenceNumber`,
-      so clients can stitch the live feed onto the `/wallet/{address}/orderHistory`
-      REST endpoint without overlap or gap.
+      `snapshotSequenceNumber` cursor); `orderChangeUpdate` is every
+      subsequent `channel_data` frame and carries one `Order` whose
+      `sequenceNumber` is strictly greater than `snapshotSequenceNumber`.
+      The cursor lets clients splice the live feed against the
+      `/wallet/{address}/orderHistory` REST endpoint without overlap or gap.
     parameters:
       address:
         description: Ethereum wallet address
         location: $message.payload#/address
     messages:
+      orderChangesSubscribed:
+        $ref: '#/components/messages/OrderChangesSubscribed'
       orderChangeUpdate:
         $ref: '#/components/messages/OrderChangeUpdate'
 
@@ -363,6 +369,7 @@ operations:
     channel:
       $ref: '#/channels/walletOrderChanges'
     messages:
+      - $ref: '#/channels/walletOrderChanges/messages/orderChangesSubscribed'
       - $ref: '#/channels/walletOrderChanges/messages/orderChangeUpdate'
     summary: Receive order change updates for wallet
 
@@ -470,6 +477,16 @@ components:
       summary: Real-time order change update for a wallet
       payload:
         $ref: '#/components/schemas/OrderChangeUpdatePayload'
+
+    OrderChangesSubscribed:
+      name: subscribed
+      title: Order Changes Subscribed
+      summary: |
+        Initial `subscribed` confirmation for the orderChanges channel. The
+        envelope is the generic subscribe-response shape; the `contents`
+        carries the typed `OrderChangesSnapshot` payload.
+      payload:
+        $ref: '#/components/schemas/OrderChangesSubscribedPayload'
 
     MarketPerpExecutionUpdate:
       name: marketPerpExecutionUpdate
@@ -841,6 +858,22 @@ components:
           title: OrderList
           items:
             $ref: './trading-schemas.json#/definitions/Order'
+
+    OrderChangesSubscribedPayload:
+      type: object
+      title: OrderChangesSubscribedPayload
+      additionalProperties: false
+      required:
+        - type
+        - channel
+        - contents
+      properties:
+        type:
+          $ref: '#/components/schemas/SubscribedMessageType'
+        channel:
+          $ref: '#/components/schemas/WalletOrderChangesChannelPattern'
+        contents:
+          $ref: './trading-schemas.json#/definitions/OrderChangesSnapshot'
 
     MarketPerpExecutionUpdateBody:
       type: object

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.8
+  version: 2.3.9
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.7
+  version: 2.3.8
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.4
+  version: 2.3.5
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -372,6 +372,7 @@ paths:
         - $ref: '#/components/parameters/SymbolParam'
         - $ref: '#/components/parameters/StartTimeParam'
         - $ref: '#/components/parameters/EndTimeParam'
+        - $ref: '#/components/parameters/ExecutionTypeParam'
       responses:
         '200':
           description: List of perp executions
@@ -530,6 +531,7 @@ paths:
         - $ref: '#/components/parameters/AddressParam'
         - $ref: '#/components/parameters/StartTimeParam'
         - $ref: '#/components/parameters/EndTimeParam'
+        - $ref: '#/components/parameters/ExecutionTypeParam'
       responses:
         '200':
           description: List of perpetual executions
@@ -773,6 +775,18 @@ components:
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000
+
+    ExecutionTypeParam:
+      name: type
+      in: query
+      required: false
+      description: Filter perp executions by type. Omit to return executions of all types.
+      schema:
+        type: string
+        enum:
+          - ORDER_MATCH
+          - LIQUIDATION
+        example: LIQUIDATION
 
     ResolutionParam:
       name: resolution

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.4
+  version: 2.2.5
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -566,11 +566,15 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /wallet/{address}/spotOrderHistory:
+  /wallet/{address}/orderHistory:
     get:
-      summary: Get wallet spot order history
+      summary: Get wallet order history
       description: |
-        Returns up to 100 historical spot order state-change events for a wallet, newest first.
+        Returns up to 100 historical order state-change events for a wallet, newest first. Today the
+        result set is spot-only (matching-engine sourced); perp will start landing here once the perp
+        order indexer is wired in. The row shape will not change between spot-only and the
+        unified result.
+
         Each row is one state transition emitted by the matching engine (`OPEN`, `PARTIALLY_FILLED`,
         `FILLED`, `CANCELLED`, `REJECTED`). The row shape matches the `Order` events published on the
         `/v2/wallet/{address}/orderChanges` WebSocket channel, so live + historical entries can be
@@ -580,7 +584,7 @@ paths:
         inclusive upper bound) set to the oldest live entry's `lastUpdateAt` to fetch the previous
         page. Deduplicate boundary entries by `(orderId, sequenceNumber)` when joining with the live
         WS feed.
-      operationId: getWalletSpotOrderHistory
+      operationId: getWalletOrderHistory
       tags:
         - Wallet Data
       parameters:

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.2
+  version: 2.2.3
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -785,6 +785,9 @@ components:
     OrderList:
       $ref: './trading-schemas.json#/definitions/OrderList'
 
+    OrderChangesSnapshot:
+      $ref: './trading-schemas.json#/definitions/OrderChangesSnapshot'
+
     Account:
       $ref: './trading-schemas.json#/definitions/Account'
 

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.6
+  version: 2.3.7
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.3
+  version: 2.3.0
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -55,12 +55,35 @@ paths:
   /marketDefinitions:
     get:
       summary: Get market definitions
+      description: 'Deprecated: use `/perpMarketDefinitions` instead. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketDefinitions
+      deprecated: true
       tags:
         - Reference Data
       responses:
         '200':
           description: List of market definitions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketDefinition'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /perpMarketDefinitions:
+    get:
+      summary: Get perp market definitions
+      description: Alias of `/marketDefinitions`, mirroring the `/spotMarketDefinitions` naming.
+      operationId: getPerpMarketDefinitions
+      tags:
+        - Reference Data
+      responses:
+        '200':
+          description: List of perp market definitions
           content:
             application/json:
               schema:
@@ -215,8 +238,9 @@ paths:
   /markets/summary:
     get:
       summary: Get market summaries
-      description: Statistics and throttled market data for all markets. Recalculated every 0.5s
+      description: 'Deprecated: use `/perpMarkets/summary` instead. Statistics and throttled market data for all markets. Recalculated every 0.5s. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketsSummary
+      deprecated: true
       tags:
         - Market Data
       responses:
@@ -233,11 +257,54 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /perpMarkets/summary:
+    get:
+      summary: Get perp market summaries
+      description: Alias of `/markets/summary`, mirroring the `/spotMarkets/summary` naming. Statistics and throttled market data for all perp markets. Recalculated every 0.5s
+      operationId: getPerpMarketsSummary
+      tags:
+        - Market Data
+      responses:
+        '200':
+          description: List of perp market summaries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /market/{symbol}/summary:
     get:
       summary: Get market summary
-      description: Statistics and throttled data for a specific market. Recalculated every 0.5s
+      description: 'Deprecated: use `/perpMarket/{symbol}/summary` instead. Statistics and throttled data for a specific market. Recalculated every 0.5s. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketSummary
+      deprecated: true
+      tags:
+        - Market Data
+      parameters:
+        - $ref: '#/components/parameters/SymbolParam'
+      responses:
+        '200':
+          description: Market summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /perpMarket/{symbol}/summary:
+    get:
+      summary: Get perp market summary
+      description: Alias of `/market/{symbol}/summary`, mirroring the `/spotMarket/{symbol}/summary` naming. Statistics and throttled data for a specific perp market. Recalculated every 0.5s
+      operationId: getPerpMarketSummary
       tags:
         - Market Data
       parameters:

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.0
+  version: 2.3.4
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.3
+  version: 2.2.4
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.0
+  version: 2.2.1
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -566,6 +566,39 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /wallet/{address}/spotOrderHistory:
+    get:
+      summary: Get wallet spot order history
+      description: |
+        Returns up to 100 historical spot order state-change events for a wallet, newest first.
+        Each row is one state transition emitted by the matching engine (`OPEN`, `PARTIALLY_FILLED`,
+        `FILLED`, `CANCELLED`, `REJECTED`). The row shape matches the `Order` events published on the
+        `/v2/wallet/{address}/orderChanges` WebSocket channel, so live + historical entries can be
+        coalesced client-side.
+
+        Pagination is cursor-based on `lastUpdateAt`. Pass the `endTime` query parameter (milliseconds,
+        inclusive upper bound) set to the oldest live entry's `lastUpdateAt` to fetch the previous
+        page. Deduplicate boundary entries by `(orderId, sequenceNumber)` when joining with the live
+        WS feed.
+      operationId: getWalletSpotOrderHistory
+      tags:
+        - Wallet Data
+      parameters:
+        - $ref: '#/components/parameters/AddressParam'
+        - $ref: '#/components/parameters/StartTimeParam'
+        - $ref: '#/components/parameters/EndTimeParam'
+      responses:
+        '200':
+          description: Paginated list of order state-change events
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /wallet/{address}/configuration:
     get:
       summary: Get wallet configuration
@@ -748,6 +781,9 @@ components:
 
     Order:
       $ref: './trading-schemas.json#/definitions/Order'
+
+    OrderList:
+      $ref: './trading-schemas.json#/definitions/OrderList'
 
     Account:
       $ref: './trading-schemas.json#/definitions/Account'

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.7
+  version: 2.3.8
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -55,12 +55,35 @@ paths:
   /marketDefinitions:
     get:
       summary: Get market definitions
+      description: 'Deprecated: use `/perpMarketDefinitions` instead. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketDefinitions
+      deprecated: true
       tags:
         - Reference Data
       responses:
         '200':
           description: List of market definitions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketDefinition'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /perpMarketDefinitions:
+    get:
+      summary: Get perp market definitions
+      description: Alias of `/marketDefinitions`, mirroring the `/spotMarketDefinitions` naming.
+      operationId: getPerpMarketDefinitions
+      tags:
+        - Reference Data
+      responses:
+        '200':
+          description: List of perp market definitions
           content:
             application/json:
               schema:
@@ -215,8 +238,9 @@ paths:
   /markets/summary:
     get:
       summary: Get market summaries
-      description: Statistics and throttled market data for all markets. Recalculated every 0.5s
+      description: 'Deprecated: use `/perpMarkets/summary` instead. Statistics and throttled market data for all markets. Recalculated every 0.5s. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketsSummary
+      deprecated: true
       tags:
         - Market Data
       responses:
@@ -233,11 +257,54 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /perpMarkets/summary:
+    get:
+      summary: Get perp market summaries
+      description: Alias of `/markets/summary`, mirroring the `/spotMarkets/summary` naming. Statistics and throttled market data for all perp markets. Recalculated every 0.5s
+      operationId: getPerpMarketsSummary
+      tags:
+        - Market Data
+      responses:
+        '200':
+          description: List of perp market summaries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /market/{symbol}/summary:
     get:
       summary: Get market summary
-      description: Statistics and throttled data for a specific market. Recalculated every 0.5s
+      description: 'Deprecated: use `/perpMarket/{symbol}/summary` instead. Statistics and throttled data for a specific market. Recalculated every 0.5s. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketSummary
+      deprecated: true
+      tags:
+        - Market Data
+      parameters:
+        - $ref: '#/components/parameters/SymbolParam'
+      responses:
+        '200':
+          description: Market summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /perpMarket/{symbol}/summary:
+    get:
+      summary: Get perp market summary
+      description: Alias of `/market/{symbol}/summary`, mirroring the `/spotMarket/{symbol}/summary` naming. Statistics and throttled data for a specific perp market. Recalculated every 0.5s
+      operationId: getPerpMarketSummary
       tags:
         - Market Data
       parameters:
@@ -305,6 +372,7 @@ paths:
         - $ref: '#/components/parameters/SymbolParam'
         - $ref: '#/components/parameters/StartTimeParam'
         - $ref: '#/components/parameters/EndTimeParam'
+        - $ref: '#/components/parameters/ExecutionTypeParam'
       responses:
         '200':
           description: List of perp executions
@@ -463,6 +531,7 @@ paths:
         - $ref: '#/components/parameters/AddressParam'
         - $ref: '#/components/parameters/StartTimeParam'
         - $ref: '#/components/parameters/EndTimeParam'
+        - $ref: '#/components/parameters/ExecutionTypeParam'
       responses:
         '200':
           description: List of perpetual executions
@@ -722,7 +791,10 @@ components:
       name: startTime
       in: query
       required: false
-      description: Return results at or after this timestamp, in milliseconds (for pagination)
+      description: >-
+        Return results at or after this time (inclusive lower bound).
+        Millisecond POSIX timestamp, matched against each execution's on-chain
+        block timestamp.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733379000
@@ -731,10 +803,27 @@ components:
       name: endTime
       in: query
       required: false
-      description: Return results at or before this timestamp, in milliseconds (for pagination)
+      description: >-
+        Return results at or before this time (inclusive upper bound).
+        Millisecond POSIX timestamp, matched against each execution's on-chain
+        block timestamp. Results are returned newest-first and capped at a
+        maximum that varies by endpoint; to page backward through history,
+        pass the oldest timestamp from the previous page.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000
+
+    ExecutionTypeParam:
+      name: type
+      in: query
+      required: false
+      description: Filter perp executions by type. Omit to return executions of all types.
+      schema:
+        type: string
+        enum:
+          - ORDER_MATCH
+          - LIQUIDATION
+        example: LIQUIDATION
 
     ResolutionParam:
       name: resolution

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.2
+  version: 2.2.3
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -685,7 +685,10 @@ components:
       name: startTime
       in: query
       required: false
-      description: Return results at or after this timestamp, in milliseconds (for pagination)
+      description: >-
+        Return results at or after this time (inclusive lower bound).
+        Millisecond POSIX timestamp, matched against each execution's on-chain
+        block timestamp.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733379000
@@ -694,7 +697,12 @@ components:
       name: endTime
       in: query
       required: false
-      description: Return results at or before this timestamp, in milliseconds (for pagination)
+      description: >-
+        Return results at or before this time (inclusive upper bound).
+        Millisecond POSIX timestamp, matched against each execution's on-chain
+        block timestamp. Results are returned newest-first and capped at a
+        maximum that varies by endpoint; to page backward through history,
+        pass the oldest timestamp from the previous page.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.1
+  version: 2.2.2
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.5
+  version: 2.3.6
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.6
+  version: 2.2.7
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.5
+  version: 2.2.6
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -382,7 +382,7 @@
       "$id": "#Order",
       "x-parser-schema-id": "Order",
       "type": "object",
-      "description": "Represents a state of an order. Emitted as openOrders snapshots, orderChanges WS events, and orderHistory REST rows. For event-style emissions (orderChanges WS, orderHistory REST), `lastUpdateAt` reflects the event time and a single order produces one row per state transition (OPEN, PARTIALLY_FILLED, FILLED, CANCELLED, REJECTED). The `sequenceNumber` field (Redis stream ID) lets clients stitch the orderChanges WS feed onto the orderHistory REST endpoint via the `snapshotSequenceNumber` returned in the orderChanges subscription response.",
+      "description": "Represents a state of an order. Emitted as openOrders snapshots, orderChanges WS events, and orderHistory REST rows. For event-style emissions (orderChanges WS, orderHistory REST), `lastUpdateAt` reflects the event time and a single order produces one row per state transition (OPEN, PARTIALLY_FILLED, FILLED, CANCELLED, REJECTED). The monotonic `sequenceNumber` lets clients stitch the orderChanges WS feed onto the orderHistory REST endpoint via the `snapshotSequenceNumber` returned in the orderChanges subscription response.",
       "required": [
         "exchangeId",
         "symbol",
@@ -464,9 +464,9 @@
           "example": 1747927089946
         },
         "sequenceNumber": {
-          "type": "string",
-          "description": "Identifier of the event that produced this state. Populated on event-style emissions (orderChanges WS, orderHistory REST). Currently the underlying Redis stream ID (`<ms_timestamp>-<sub_seq>`). Monotonic in real time and survives matching-engine restarts (timestamp-based). Together with `snapshotSequenceNumber` from the orderChanges subscription response it lets a client stitch the REST history onto the live WS stream without gaps or duplicates.",
-          "example": "1747927089946-0"
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Monotonic identifier of the event that produced this state. Populated on event-style emissions (orderChanges WS, orderHistory REST). Encoded from the underlying Redis stream ID `<ms>-<sub_seq>` as `ms * 1000 + sub_seq` (sub_seq assumed < 1000). Survives matching-engine restarts because the ms component is wall-clock based. Together with `snapshotSequenceNumber` from the orderChanges subscription response it lets a client stitch the REST history onto the live WS stream — every subsequent WS message carries a strictly greater value.",
+          "example": 1747927089946000
         }
       },
       "additionalProperties": true
@@ -476,7 +476,7 @@
       "$id": "#OrderChangesSnapshot",
       "x-parser-schema-id": "OrderChangesSnapshot",
       "type": "object",
-      "description": "Initial payload returned in the `subscribed` confirmation for the `/v2/wallet/{address}/orderChanges` WS channel. Combines the current open orders snapshot with a `snapshotSequenceNumber` cursor; every subsequent orderChanges WS message carries a `sequenceNumber` that is monotonically greater than `snapshotSequenceNumber`, so clients can splice the live feed against the orderHistory REST endpoint without overlap or gap.",
+      "description": "Initial payload returned in the `subscribed` confirmation for the `/v2/wallet/{address}/orderChanges` WS channel. Combines the current open orders snapshot with a `snapshotSequenceNumber` cursor; every subsequent orderChanges WS message carries a strictly greater `sequenceNumber`, so clients can splice the live feed against the orderHistory REST endpoint without overlap or gap.",
       "required": [
         "data",
         "snapshotSequenceNumber"
@@ -489,9 +489,9 @@
           }
         },
         "snapshotSequenceNumber": {
-          "type": "string",
-          "description": "Redis stream ID (`<ms_timestamp>-<sub_seq>`) that the snapshot was taken at. All subsequent orderChanges messages on this subscription have `sequenceNumber` > `snapshotSequenceNumber`.",
-          "example": "1747927089946-0"
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Monotonic cursor (same encoding as `Order.sequenceNumber`: `ms * 1000 + sub_seq` from the Redis stream ID) marking the boundary that the snapshot was taken at. All subsequent orderChanges messages on this subscription have `sequenceNumber` > `snapshotSequenceNumber`.",
+          "example": 1747927089946000
         }
       },
       "additionalProperties": true

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -853,8 +853,7 @@
         "liquidationMarginParameter",
         "initialMarginParameter",
         "maxLeverage",
-        "oiCap",
-        "status"
+        "oiCap"
       ],
       "properties": {
         "symbol": {
@@ -898,12 +897,6 @@
           "$ref": "#/definitions/UnsignedDecimal",
           "description": "Maximum one-sided open interest in units for a given market.",
           "example": "10000"
-        },
-        "status": {
-          "type": "string",
-          "enum": ["TRADING", "REDUCE_ONLY", "SETTLED"],
-          "description": "Trading status of the market, derived from open interest and the open interest cap (TRADING = open for trading, REDUCE_ONLY = positions may only be reduced, SETTLED = market has been settled).",
-          "example": "TRADING"
         }
       },
       "additionalProperties": true

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -1372,12 +1372,12 @@
       "properties": {
         "orderId": {
           "type": "string",
-          "description": "Internal matching engine order ID to cancel. Provide either orderId OR clientOrderId, not both. For spot markets, this is the order ID returned in the CreateOrderResponse.",
+          "description": "Internal matching engine order ID to cancel. At least one of `orderId` or `clientOrderId` must be provided; if both are supplied the server treats `orderId` as the canonical identifier and `clientOrderId` is ignored. For spot markets, this is the order ID returned in the CreateOrderResponse.",
           "example": "490346525705109504"
         },
         "clientOrderId": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Client-provided order ID for tracking and correlation. Provide either orderId OR clientOrderId, not both. This is the same clientOrderId provided in CreateOrderRequest.",
+          "description": "Client-provided order ID for tracking and correlation. At least one of `orderId` or `clientOrderId` must be provided; `clientOrderId` is consulted only when `orderId` is absent. This is the same clientOrderId provided in CreateOrderRequest.",
           "example": "123456789"
         },
         "accountId": {

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -382,6 +382,7 @@
       "$id": "#Order",
       "x-parser-schema-id": "Order",
       "type": "object",
+      "description": "Represents a state of an order. Emitted as openOrders snapshots, orderChanges WS events, and orderHistory REST rows. For event-style emissions (orderChanges, orderHistory), `sequenceNumber` identifies the state transition and `lastUpdateAt` is the event time.",
       "required": [
         "exchangeId",
         "symbol",
@@ -454,13 +455,40 @@
         },
         "createdAt": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Creation timestamp (milliseconds)",
+          "description": "Order creation timestamp (milliseconds since epoch).",
           "example": 1747927089946
         },
         "lastUpdateAt": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Last update timestamp (milliseconds)",
+          "description": "Timestamp of this state, in milliseconds since epoch. For openOrders snapshots this is the order creation time; for orderChanges WS events and orderHistory REST rows this is the matching engine event time. Used as the cursor for `orderHistory` pagination via the `endTime` query parameter (inclusive upper bound).",
           "example": 1747927089946
+        },
+        "sequenceNumber": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Matching engine monotonic sequence number for the state transition. Populated on event-style emissions (orderChanges WS, orderHistory REST). Together with `orderId` it uniquely identifies a state-change event and is the recommended deduplication key when coalescing the live WS feed with paginated REST history.",
+          "example": 152954
+        }
+      },
+      "additionalProperties": true
+    },
+    "OrderList": {
+      "title": "OrderList",
+      "$id": "#OrderList",
+      "x-parser-schema-id": "OrderList",
+      "type": "object",
+      "required": [
+        "data",
+        "meta"
+      ],
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Order"
+          }
+        },
+        "meta": {
+          "$ref": "#/definitions/PaginationMeta"
         }
       },
       "additionalProperties": true

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -382,7 +382,7 @@
       "$id": "#Order",
       "x-parser-schema-id": "Order",
       "type": "object",
-      "description": "Represents a state of an order. Emitted as openOrders snapshots, orderChanges WS events, and orderHistory REST rows. For event-style emissions (orderChanges WS, orderHistory REST), `lastUpdateAt` reflects the event time and a single order produces one row per state transition (OPEN, PARTIALLY_FILLED, FILLED, CANCELLED, REJECTED). Recommended deduplication key when coalescing WS + REST is the composite `(orderId, cumQty, status)`.",
+      "description": "Represents a state of an order. Emitted as openOrders snapshots, orderChanges WS events, and orderHistory REST rows. For event-style emissions (orderChanges WS, orderHistory REST), `lastUpdateAt` reflects the event time and a single order produces one row per state transition (OPEN, PARTIALLY_FILLED, FILLED, CANCELLED, REJECTED). The `sequenceNumber` field (Redis stream ID) lets clients stitch the orderChanges WS feed onto the orderHistory REST endpoint via the `snapshotSequenceNumber` returned in the orderChanges subscription response.",
       "required": [
         "exchangeId",
         "symbol",
@@ -462,6 +462,36 @@
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Timestamp of this state, in milliseconds since epoch. For openOrders snapshots this is the order creation time; for orderChanges WS events and orderHistory REST rows this is the matching engine event time. Used as the cursor for `orderHistory` pagination via the `endTime` query parameter (inclusive upper bound).",
           "example": 1747927089946
+        },
+        "sequenceNumber": {
+          "type": "string",
+          "description": "Identifier of the event that produced this state. Populated on event-style emissions (orderChanges WS, orderHistory REST). Currently the underlying Redis stream ID (`<ms_timestamp>-<sub_seq>`). Monotonic in real time and survives matching-engine restarts (timestamp-based). Together with `snapshotSequenceNumber` from the orderChanges subscription response it lets a client stitch the REST history onto the live WS stream without gaps or duplicates.",
+          "example": "1747927089946-0"
+        }
+      },
+      "additionalProperties": true
+    },
+    "OrderChangesSnapshot": {
+      "title": "OrderChangesSnapshot",
+      "$id": "#OrderChangesSnapshot",
+      "x-parser-schema-id": "OrderChangesSnapshot",
+      "type": "object",
+      "description": "Initial payload returned in the `subscribed` confirmation for the `/v2/wallet/{address}/orderChanges` WS channel. Combines the current open orders snapshot with a `snapshotSequenceNumber` cursor; every subsequent orderChanges WS message carries a `sequenceNumber` that is monotonically greater than `snapshotSequenceNumber`, so clients can splice the live feed against the orderHistory REST endpoint without overlap or gap.",
+      "required": [
+        "data",
+        "snapshotSequenceNumber"
+      ],
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Order"
+          }
+        },
+        "snapshotSequenceNumber": {
+          "type": "string",
+          "description": "Redis stream ID (`<ms_timestamp>-<sub_seq>`) that the snapshot was taken at. All subsequent orderChanges messages on this subscription have `sequenceNumber` > `snapshotSequenceNumber`.",
+          "example": "1747927089946-0"
         }
       },
       "additionalProperties": true

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -393,7 +393,8 @@
         "orderType",
         "status",
         "createdAt",
-        "lastUpdateAt"
+        "lastUpdateAt",
+        "sequenceNumber"
       ],
       "properties": {
         "exchangeId": {
@@ -465,7 +466,7 @@
         },
         "sequenceNumber": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Monotonic identifier of the event that produced this state. Populated on event-style emissions (orderChanges WS, orderHistory REST). Encoded from the underlying Redis stream ID `<ms>-<sub_seq>` as `ms * 1000 + sub_seq` (sub_seq assumed < 1000). Survives matching-engine restarts because the ms component is wall-clock based. Together with `snapshotSequenceNumber` from the orderChanges subscription response it lets a client stitch the REST history onto the live WS stream — every subsequent WS message carries a strictly greater value.",
+          "description": "Monotonic identifier of this order state, comparable across all sources. Encoded as `<ms> * 1000 + <sub_seq>`. On event-style emissions (orderChanges WS, orderHistory REST) the value is derived from the underlying Redis stream ID (`<ms>-<sub_seq>`, `sub_seq < 1000` assumed). On non-event emissions (openOrders snapshot rows, perp orders from the conditional-orders table) the value falls back to `lastUpdateAt * 1000` — same encoding space, still monotonic per order. Together with `snapshotSequenceNumber` from the orderChanges subscription response, this lets a client stitch the REST history onto the live WS stream — every subsequent WS message carries a strictly greater value.",
           "example": 1747927089946000
         }
       },

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -426,6 +426,16 @@
           "description": "Total Executed quantity accross all fills where the order is involved.",
           "example": "0.5"
         },
+        "firstFillId": {
+          "type": "string",
+          "description": "Matching-engine fill nonce of the first fill this update represents. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. For a taker update, the first fill of its matching round; for a maker update, its single fill. Present only on fill updates; absent for non-fill updates and resting-order snapshots.",
+          "example": "7205759403792794624"
+        },
+        "fillCount": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Number of fills this update represents — the length of the contiguous nonce range starting at firstFillId. For a taker update, the fills produced in its matching round; for a maker update, 1. Present only on fill updates; absent otherwise (so it is >= 1 whenever present).",
+          "example": 2
+        },
         "side": {
           "$ref": "#/definitions/Side"
         },
@@ -1411,6 +1421,16 @@
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Client-provided order ID echoed back from the request",
           "example": "123456789"
+        },
+        "firstFillId": {
+          "type": "string",
+          "description": "Matching-engine fill nonce of the first fill this order produced on entry. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. Absent if the order did not fill on entry. For a non-IOC (resting) taker, the same first nonce also appears on the order's taker update in the orderChanges channel; an IOC taker is not published to orderChanges, so this response is the only place its fill range is delivered.",
+          "example": "7205759403792794624"
+        },
+        "fillCount": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Number of fills this order produced on entry — the length of the contiguous nonce range starting at firstFillId. Absent if the order did not fill on entry (so it is >= 1 whenever present).",
+          "example": 2
         }
       },
       "additionalProperties": true
@@ -1426,12 +1446,12 @@
       "properties": {
         "orderId": {
           "type": "string",
-          "description": "Internal matching engine order ID to cancel. Provide either orderId OR clientOrderId, not both. For spot markets, this is the order ID returned in the CreateOrderResponse.",
+          "description": "Internal matching engine order ID to cancel. At least one of `orderId` or `clientOrderId` must be provided; if both are supplied the server treats `orderId` as the canonical identifier and `clientOrderId` is ignored. For spot markets, this is the order ID returned in the CreateOrderResponse.",
           "example": "490346525705109504"
         },
         "clientOrderId": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Client-provided order ID for tracking and correlation. Provide either orderId OR clientOrderId, not both. This is the same clientOrderId provided in CreateOrderRequest.",
+          "description": "Client-provided order ID for tracking and correlation. At least one of `orderId` or `clientOrderId` must be provided; `clientOrderId` is consulted only when `orderId` is absent. This is the same clientOrderId provided in CreateOrderRequest.",
           "example": "123456789"
         },
         "accountId": {

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -424,6 +424,16 @@
           "description": "Total Executed quantity accross all fills where the order is involved.",
           "example": "0.5"
         },
+        "firstFillId": {
+          "type": "string",
+          "description": "Matching-engine fill nonce of the first fill this update represents. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. For a taker update, the first fill of its matching round; for a maker update, its single fill. Present only on fill updates; absent for non-fill updates and resting-order snapshots.",
+          "example": "7205759403792794624"
+        },
+        "fillCount": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Number of fills this update represents — the length of the contiguous nonce range starting at firstFillId. For a taker update, the fills produced in its matching round; for a maker update, 1. Present only on fill updates; absent otherwise (so it is >= 1 whenever present).",
+          "example": 2
+        },
         "side": {
           "$ref": "#/definitions/Side"
         },
@@ -1357,6 +1367,16 @@
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Client-provided order ID echoed back from the request",
           "example": "123456789"
+        },
+        "firstFillId": {
+          "type": "string",
+          "description": "Matching-engine fill nonce of the first fill this order produced on entry. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. Absent if the order did not fill on entry. For a non-IOC (resting) taker, the same first nonce also appears on the order's taker update in the orderChanges channel; an IOC taker is not published to orderChanges, so this response is the only place its fill range is delivered.",
+          "example": "7205759403792794624"
+        },
+        "fillCount": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Number of fills this order produced on entry — the length of the contiguous nonce range starting at firstFillId. Absent if the order did not fill on entry (so it is >= 1 whenever present).",
+          "example": 2
         }
       },
       "additionalProperties": true

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -382,7 +382,7 @@
       "$id": "#Order",
       "x-parser-schema-id": "Order",
       "type": "object",
-      "description": "Represents a state of an order. Emitted as openOrders snapshots, orderChanges WS events, and orderHistory REST rows. For event-style emissions (orderChanges, orderHistory), `sequenceNumber` identifies the state transition and `lastUpdateAt` is the event time.",
+      "description": "Represents a state of an order. Emitted as openOrders snapshots, orderChanges WS events, and orderHistory REST rows. For event-style emissions (orderChanges WS, orderHistory REST), `lastUpdateAt` reflects the event time and a single order produces one row per state transition (OPEN, PARTIALLY_FILLED, FILLED, CANCELLED, REJECTED). Recommended deduplication key when coalescing WS + REST is the composite `(orderId, cumQty, status)`.",
       "required": [
         "exchangeId",
         "symbol",
@@ -462,11 +462,6 @@
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Timestamp of this state, in milliseconds since epoch. For openOrders snapshots this is the order creation time; for orderChanges WS events and orderHistory REST rows this is the matching engine event time. Used as the cursor for `orderHistory` pagination via the `endTime` query parameter (inclusive upper bound).",
           "example": 1747927089946
-        },
-        "sequenceNumber": {
-          "$ref": "#/definitions/UnsignedInteger",
-          "description": "Matching engine monotonic sequence number for the state transition. Populated on event-style emissions (orderChanges WS, orderHistory REST). Together with `orderId` it uniquely identifies a state-change event and is the recommended deduplication key when coalescing the live WS feed with paginated REST history.",
-          "example": 152954
         }
       },
       "additionalProperties": true

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -853,7 +853,8 @@
         "liquidationMarginParameter",
         "initialMarginParameter",
         "maxLeverage",
-        "oiCap"
+        "oiCap",
+        "status"
       ],
       "properties": {
         "symbol": {
@@ -897,6 +898,12 @@
           "$ref": "#/definitions/UnsignedDecimal",
           "description": "Maximum one-sided open interest in units for a given market.",
           "example": "10000"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["TRADING", "REDUCE_ONLY", "SETTLED"],
+          "description": "Trading status of the market, derived from open interest and the open interest cap (TRADING = open for trading, REDUCE_ONLY = positions may only be reduced, SETTLED = market has been settled).",
+          "example": "TRADING"
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
## Summary
- Adds `GET /wallet/{address}/spotOrderHistory` returning `OrderList` (`{ data: Order[], meta: PaginationMeta }`). Newest first, cursor on `endTime` (ms, inclusive upper bound) — same pattern as `perpExecutions`.
- Adds the `OrderList` schema (Order array + PaginationMeta wrapper).
- Clarifies `Order.lastUpdateAt` semantics: equals `createdAt` on openOrders snapshots; equals the matching engine event time on orderChanges WS / orderHistory REST.
- Clarifies that orderChanges WS and orderHistory REST emit **one row per state transition** (OPEN, PARTIALLY_FILLED, FILLED, CANCELLED, REJECTED), matching Hyperliquid's `userHistoricalOrders` shape.

## Dedup contract
Recommended client-side dedup key when coalescing live WS + paginated REST: composite `(orderId, cumQty, status)`. No per-event sequence is exposed (it would be sourced from the ME's monotonic counter which resets to 0 on Memorystore wipes — not a reliable global key).

## Why
The off-chain monorepo's order history writer ([Reya-Labs/reya-off-chain-monorepo#2646](https://github.com/Reya-Labs/reya-off-chain-monorepo/pull/2646)) needs this contract to unblock the FE order history tab built on `useStreamedHistory` (live WS + paginated REST coalesce).

## Test plan
- [ ] Version bumped (2.2.2) so the off-chain monorepo's `generation-consistency` CI picks up the new schema.
- [ ] Off-chain PR submodule points to this tag once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)