### PR TITLE
feat(spot-busts): add decoded reasonName/reasonArgs to SpotExecutionBust

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.0
+  version: 2.2.1
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.0
+  version: 2.2.1
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.0
+  version: 2.2.1
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -779,8 +779,24 @@
         },
         "reason": {
           "type": "string",
-          "description": "Hex-encoded revert reason bytes",
-          "example": "08c379a0..."
+          "description": "Raw hex-encoded revert reason bytes emitted by the on-chain FailedFillBytes event. Starts with the 4-byte custom-error selector. Use reasonName/reasonArgs for the decoded form.",
+          "example": "0xf2a27bca00000000000000000000000000000000000000000000000000000002540d8985ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffb91258"
+        },
+        "reasonName": {
+          "type": ["string", "null"],
+          "description": "Decoded name of the on-chain custom error that caused the bust (e.g. SignatureExpired, NegativeAccountRealBalance). Null when the selector is not recognised; consumers should fall back to inspecting reason.",
+          "example": "NegativeAccountRealBalance"
+        },
+        "reasonArgs": {
+          "type": ["object", "null"],
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Decoded arguments of the on-chain custom error, keyed by Solidity parameter name. Values are stringified ABI-decoded values. Empty object when the error has no parameters; null when reasonName is null.",
+          "example": {
+            "accountId": "10000063365",
+            "realBalance": "-4575272"
+          }
         },
         "timestamp": {
           "$ref": "#/definitions/UnsignedInteger",


### PR DESCRIPTION
## Summary
Adds two optional sibling fields to the V2 `SpotExecutionBust` schema so consumers can read a decoded Solidity custom-error name + arguments instead of having to keccak-match a 4-byte selector themselves.

- `reasonName: string | null` — decoded error name (e.g. `SignatureExpired`, `NegativeAccountRealBalance`)
- `reasonArgs: { [k: string]: string } | null` — ABI-decoded arguments keyed by Solidity parameter name

Both are non-required and default to `null` for unknown selectors and pre-existing rows, so this is a strictly additive schema change.

## Why
Today, a sample of the prod `spot_execution_busts` table looks like:

| selector | decoded | count |
|---|---|---|
| `0x0819bdcd` | `SignatureExpired()` | 58 |
| `0xf2a27bca` | `NegativeAccountRealBalance(uint128,int256)` | 21 |

Every consumer (frontends, market-maker bots, support) has to maintain a private selector→error map to do anything useful with this. Decoding once in the API removes that duplication.

## Test plan
- [ ] CI passes (schema validation, generation parity)
- [ ] After merge, the auto-tagged version is pulled into the off-chain monorepo follow-up PR which wires the actual decoder

## Follow-up
The off-chain monorepo PR will:
1. Bump the specs submodule to the auto-generated tag from this PR
2. Regenerate `api-v2-sdk`
3. Add a selector→error decoder in `common-backend`
4. Populate `reasonName`/`reasonArgs` in both `transformSpotExecutionBust` (REST) and `convertToSpotExecutionBust` (WS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trading execution error responses now include two new optional fields with decoded error information: custom error names and decoded error arguments, offering greater transparency into on-chain execution failures.

* **Chores**
  * Updated AsyncAPI and OpenAPI specification versions to 2.2.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Reya-Labs/reya-api-specs/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->