### PR TITLE
feat: add sequenceNumber to SpotExecutionBust schema

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.0
+  version: 2.2.1
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.0
+  version: 2.2.1
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.0
+  version: 2.2.1
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -736,7 +736,8 @@
         "side",
         "price",
         "reason",
-        "timestamp"
+        "timestamp",
+        "sequenceNumber"
       ],
       "properties": {
         "symbol": {
@@ -786,6 +787,11 @@
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Block timestamp (milliseconds)",
           "example": 1747927089946
+        },
+        "sequenceNumber": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Execution sequence number, increases by 1 for every spot execution bust in reya chain",
+          "example": 152954
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
## Summary

- Add required `sequenceNumber` field to `SpotExecutionBust` schema in `trading-schemas.json`
- Mirrors the existing `SpotExecution.sequenceNumber` shipped in #37
- Sourced from `spot_execution_busts.event_sequence_number` on the backend
- Lets API consumers detect gaps and order spot execution bust events deterministically across REST and WS
- Bump all three spec versions: 2.2.0 → 2.2.1

## Test plan

- [ ] Schema validates (CI lint)
- [ ] Generated SDK consistency check passes in `reya-off-chain-monorepo` after merge + auto-tag (PR there will be opened separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API specification versions to 2.2.1

* **Bug Fixes**
  * Enhanced validation requirements for spot execution records by making the sequence number field mandatory and clarifying its behavior in the Reya chain

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Reya-Labs/reya-api-specs/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->