### PR TITLE
docs(ws-exec): clarify EIP-712 envelope field is deadline, not expiresAfter

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.0
+  version: 2.3.1
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -7,7 +7,7 @@ info:
 
     Payload bodies are reused verbatim from REST via `$ref` into `trading-schemas.json`. Request/response envelopes are id-correlated.
 
-    Auth is per-message: each `createOrder` / `cancelOrder` / `cancelAll` frame carries its own EIP-712 signature (`signature`, `nonce`, `signerWallet`, `expiresAfter`), validated server-side per-frame and byte-identical to the REST signing model. There is no per-connection handshake or session, so no `security:` scheme is declared on the servers.
+    Auth is per-message: each `createOrder` / `cancelOrder` / `cancelAll` frame carries its own EIP-712 signature (`signature`, `nonce`, `signerWallet`, `deadline`), validated server-side per-frame and byte-identical to the REST signing model. `deadline` is the EIP-712 envelope's signature-validity window — distinct from `expiresAfter`, which `createOrder` payloads optionally carry as the on-chain `OrderDetails.orderExpiry` (order lifetime). There is no per-connection handshake or session, so no `security:` scheme is declared on the servers.
 
     Heartbeat: server-side liveness uses RFC 6455 protocol-level pings (handled automatically by any standards-compliant client WebSocket library — no application-level code is required on the client). The server closes the connection after 120 seconds of inbound silence. Closing the WS has zero persistent side effects — an in-flight `createOrder` whose response can't be delivered still settles on-chain (same as a REST timeout). Clients may *optionally* send `{type:"ping", id?}` JSON frames for explicit application-level RTT or correlation probes; the server replies with `{type:"pong", id?}` echoing the `id`.
 

--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -112,9 +112,9 @@ operations:
         $ref: '#/channels/operations'
       messages:
         - $ref: '#/channels/operations/messages/cancelAllResponseMessage'
-    summary: Cancel all orders for an account on a market
+    summary: Cancel all orders for an account, optionally scoped to a market
     description: |
-      Client mass-cancels all open orders for an account on a given (spot) market. The `payload` body is identical to the REST `POST /v2/cancelAll` body (existing `MassCancelRequest` schema). Perp mass-cancel is not supported — sending one returns the same not-supported error REST returns today. Server replies with `CancelAllResponseMessage` correlated by the same `id`.
+      Client mass-cancels open orders for an account, optionally scoped to a specific market via `symbol` (omit to cancel across all the signer's markets). The `payload` body is identical to the REST `POST /v2/cancelAll` body (existing `MassCancelRequest` schema). Supports both spot and perp markets via the unified `marketId` namespace. Server replies with `CancelAllResponseMessage` correlated by the same `id`.
 
   sendPing:
     action: send

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.0
+  version: 2.3.1
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.0
+  version: 2.3.1
   contact:
     name: Reya Network
     url: https://reya.xyz


### PR DESCRIPTION
## Summary

Two doc-only fixes to `asyncapi-exec-v2.yaml` to bring the WS order-entry spec in line with the perpOB target state already reflected in the schemas and the REST spec.

### Fix 1: EIP-712 envelope field is `deadline`, not `expiresAfter`

The auth description listed `expiresAfter` as one of the per-message EIP-712 signature fields, but on feat/perpOB the signed envelope deadline is `deadline` (sig validity, server-enforced at entry), while `expiresAfter` carries `OrderDetails.orderExpiry` (order lifetime, on-chain enforced) and only appears on `createOrder` payloads.

### Fix 2: Drop stale "perp mass-cancel not supported" claim from sendCancelAll

The mass-cancel description was inherited from main, where the matching engine was spot-only and perp mass-cancel went through a different path. On feat/perpOB the off-chain handler (`massCancelMatchingEngineOrders` in `tradingPrivateV2.controller.matching-engine.ts`) dispatches both spot and perp through the matching engine via the unified `marketId` namespace. The REST counterpart (`openapi-trading-v2.yaml`, `/cancelAll`) already documents this — bringing the WS spec in line.

The actual referenced schemas (`trading-schemas.json#/definitions/CreateOrderRequest`, `CancelOrderRequest`, `MassCancelRequest`) are unchanged — these are purely description-text corrections. No schemas updated, no generated types affected.

## Context

Surfaced during off-chain monorepo reconciliation work ([PRO-126](https://linear.app/reya-labs/issue/PRO-126)) merging `main` (api-specs 2.2.1, single-field model) into the perpOB chain (api-specs 2.3.x, two-field model + unified mass-cancel). Reading the ws-exec spec gave a false impression of the order-entry contract.

## Test plan

- [x] Visual diff confirms only description / summary strings changed
- [ ] AsyncAPI codegen against this branch produces byte-identical output to before for all generated types (description strings don't affect generated types; only the version field in `info` shifted, which is the automated 2.3.0 → 2.3.1 bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)