### PR TITLE
Fix startTime/endTime param descriptions: ms timestamp, not sequence number

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.3
+  version: 2.3.4
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.3
+  version: 2.3.4
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.3
+  version: 2.3.4
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -697,7 +697,10 @@ components:
       name: startTime
       in: query
       required: false
-      description: Return results after this sequence number (for pagination)
+      description: >-
+        Return results at or after this time (inclusive lower bound).
+        Millisecond POSIX timestamp, matched against each execution's on-chain
+        block timestamp.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733379000
@@ -706,7 +709,12 @@ components:
       name: endTime
       in: query
       required: false
-      description: Return results before this sequence number (for pagination)
+      description: >-
+        Return results at or before this time (inclusive upper bound).
+        Millisecond POSIX timestamp, matched against each execution's on-chain
+        block timestamp. Results are returned newest-first and capped at 100;
+        to page backward through history, pass the oldest timestamp from the
+        previous page.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000


### PR DESCRIPTION
## Problem

`StartTimeParam` / `EndTimeParam` (used by `getWalletPerpExecutions`,
`getWalletSpotExecutions`, `getWalletExecutionBusts`) were described as
*"Return results after/before this sequence number (for pagination)"* — but the
implementation treats them as **millisecond POSIX timestamps**, not sequence
numbers. This is a top integrator-confusion point (the param **name** and
**example** already imply a timestamp; only the description disagreed).

## Evidence (off-chain `tradingV2.controller.ts`, `getPaginatedQueryParams`)

- `startTime` / `endTime` are divided by `1000` (ms → s) and filtered on
  **`block_timestamp`** with inclusive `gte` / `lte`.
- Results are ordered `block_timestamp` **DESC** (newest-first) and capped at
  **100** (`PAGINATED_QUERY_ITEM_LIMIT`).
- A sibling endpoint even validates *"endTime must be a valid millisecond posix
  timestamp"*.

## Fix

Rewrite both descriptions to: millisecond POSIX timestamp, matched against each
execution's on-chain block timestamp (inclusive); document newest-first /
100-cap / backward-paging on `endTime`. No schema/behaviour change — wording
only.

> Note: targeted at `feat/perpOB`. Needs to flow through the spec release/tag
> process to reach the rendered REST reference on docs.reya.xyz. If the same
> stale wording exists on `main`, it should land there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)