### PR TITLE
docs(executions): expand startTime/endTime param descriptions

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.2
+  version: 2.2.3
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.2
+  version: 2.2.3
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -700,9 +700,9 @@ components:
       description: >-
         Return results at or before this time (inclusive upper bound).
         Millisecond POSIX timestamp, matched against each execution's on-chain
-        block timestamp. Results are returned newest-first and capped at 100;
-        to page backward through history, pass the oldest timestamp from the
-        previous page.
+        block timestamp. Results are returned newest-first and capped at a
+        maximum that varies by endpoint; to page backward through history,
+        pass the oldest timestamp from the previous page.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.2
+  version: 2.2.3
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -685,7 +685,10 @@ components:
       name: startTime
       in: query
       required: false
-      description: Return results at or after this timestamp, in milliseconds (for pagination)
+      description: >-
+        Return results at or after this time (inclusive lower bound).
+        Millisecond POSIX timestamp, matched against each execution's on-chain
+        block timestamp.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733379000
@@ -694,7 +697,12 @@ components:
       name: endTime
       in: query
       required: false
-      description: Return results at or before this timestamp, in milliseconds (for pagination)
+      description: >-
+        Return results at or before this time (inclusive upper bound).
+        Millisecond POSIX timestamp, matched against each execution's on-chain
+        block timestamp. Results are returned newest-first and capped at 100;
+        to page backward through history, pass the oldest timestamp from the
+        previous page.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000


### PR DESCRIPTION
Clarify that startTime/endTime are inclusive bounds matched against each execution's on-chain block timestamp, and document the newest-first / 100-cap / backward-paging behaviour on endTime.

Ports the richer wording from #47 (which targeted feat/perpOB) onto main. main already carried the correct "milliseconds" wording from #36, so this is a clarity improvement rather than a behaviour fix.

Lockstep patch bump 2.2.2 -> 2.2.3 across the three v2 spec files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated time-based filtering parameter documentation to clarify boundary inclusivity, timestamp precision, and pagination behavior.

* **Chores**
  * Bumped specification versions across API documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->