### PR TITLE
feat: document perp* /v2 route + channel aliases (PRO-107)

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.3
+  version: 2.3.0
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -60,14 +60,16 @@ channels:
 
   marketsSummary:
     address: /v2/markets/summary
-    description: Real-time updates for all market summaries
+    description: 'Deprecated: use `/v2/perpMarkets/summary` instead. Real-time updates for all market summaries. This un-prefixed channel still works but will be removed once integrators have migrated to the `perp*` naming. (AsyncAPI 3.0 has no native `deprecated` field on channels; flagged via `x-deprecated`.)'
+    x-deprecated: true
     messages:
       marketsSummaryUpdate:
         $ref: '#/components/messages/MarketsSummaryUpdate'
 
   marketSummary:
     address: /v2/market/{symbol}/summary
-    description: Real-time updates for a specific market's summary
+    description: 'Deprecated: use `/v2/perpMarket/{symbol}/summary` instead. Real-time updates for a specific market''s summary. This un-prefixed channel still works but will be removed once integrators have migrated to the `perp*` naming. (AsyncAPI 3.0 has no native `deprecated` field on channels; flagged via `x-deprecated`.)'
+    x-deprecated: true
     parameters:
       symbol:
         description: Trading symbol (e.g., BTCRUSDPERP, ETHRUSD)
@@ -312,7 +314,8 @@ operations:
       $ref: '#/channels/marketsSummary'
     messages:
       - $ref: '#/channels/marketsSummary/messages/marketsSummaryUpdate'
-    summary: Receive market summaries updates
+    summary: 'Deprecated: use receivePerpMarketsSummary instead. Receive market summaries updates.'
+    x-deprecated: true
 
   receiveMarketSummary:
     action: receive
@@ -320,7 +323,8 @@ operations:
       $ref: '#/channels/marketSummary'
     messages:
       - $ref: '#/channels/marketSummary/messages/marketSummaryUpdate'
-    summary: Receive specific market summary updates
+    summary: 'Deprecated: use receivePerpMarketSummary instead. Receive specific market summary updates.'
+    x-deprecated: true
 
   receivePerpMarketsSummary:
     action: receive

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -76,9 +76,6 @@ channels:
       marketSummaryUpdate:
         $ref: '#/components/messages/MarketSummaryUpdate'
 
-  # PRO-107: perp-prefixed aliases of the un-prefixed summary channels, mirroring
-  # the spot* naming. The server collapses these onto the canonical un-prefixed
-  # channel; subscribing under either name yields identical data.
   perpMarketsSummary:
     address: /v2/perpMarkets/summary
     description: Alias of `/v2/markets/summary` (mirrors `/v2/spotMarkets/summary`). Real-time updates for all perp market summaries
@@ -325,7 +322,6 @@ operations:
       - $ref: '#/channels/marketSummary/messages/marketSummaryUpdate'
     summary: Receive specific market summary updates
 
-  # PRO-107: perp-prefixed alias operations (same payloads as the un-prefixed channels).
   receivePerpMarketsSummary:
     action: receive
     channel:

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.3
+  version: 2.3.0
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network
@@ -71,6 +71,27 @@ channels:
     parameters:
       symbol:
         description: Trading symbol (e.g., BTCRUSDPERP, ETHRUSD)
+        location: $message.payload#/symbol
+    messages:
+      marketSummaryUpdate:
+        $ref: '#/components/messages/MarketSummaryUpdate'
+
+  # PRO-107: perp-prefixed aliases of the un-prefixed summary channels, mirroring
+  # the spot* naming. The server collapses these onto the canonical un-prefixed
+  # channel; subscribing under either name yields identical data.
+  perpMarketsSummary:
+    address: /v2/perpMarkets/summary
+    description: Alias of `/v2/markets/summary` (mirrors `/v2/spotMarkets/summary`). Real-time updates for all perp market summaries
+    messages:
+      marketsSummaryUpdate:
+        $ref: '#/components/messages/MarketsSummaryUpdate'
+
+  perpMarketSummary:
+    address: /v2/perpMarket/{symbol}/summary
+    description: Alias of `/v2/market/{symbol}/summary` (mirrors `/v2/spotMarket/{symbol}/summary`). Real-time updates for a specific perp market's summary
+    parameters:
+      symbol:
+        description: Trading symbol (e.g., BTCRUSDPERP)
         location: $message.payload#/symbol
     messages:
       marketSummaryUpdate:
@@ -303,6 +324,23 @@ operations:
     messages:
       - $ref: '#/channels/marketSummary/messages/marketSummaryUpdate'
     summary: Receive specific market summary updates
+
+  # PRO-107: perp-prefixed alias operations (same payloads as the un-prefixed channels).
+  receivePerpMarketsSummary:
+    action: receive
+    channel:
+      $ref: '#/channels/perpMarketsSummary'
+    messages:
+      - $ref: '#/channels/perpMarketsSummary/messages/marketsSummaryUpdate'
+    summary: Receive perp market summaries updates (alias of receiveMarketsSummary)
+
+  receivePerpMarketSummary:
+    action: receive
+    channel:
+      $ref: '#/channels/perpMarketSummary'
+    messages:
+      - $ref: '#/channels/perpMarketSummary/messages/marketSummaryUpdate'
+    summary: Receive specific perp market summary updates (alias of receiveMarketSummary)
 
   receiveSpotMarketsSummary:
     action: receive

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -72,8 +72,6 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  # PRO-107: perp-prefixed alias of /marketDefinitions, mirroring the spot* naming.
-  # Same handler/response; the un-prefixed route is kept for back-compat.
   /perpMarketDefinitions:
     get:
       summary: Get perp market definitions
@@ -256,7 +254,6 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  # PRO-107: perp-prefixed alias of /markets/summary, mirroring the spot* naming.
   /perpMarkets/summary:
     get:
       summary: Get perp market summaries
@@ -299,7 +296,6 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  # PRO-107: perp-prefixed alias of /market/{symbol}/summary, mirroring the spot* naming.
   /perpMarket/{symbol}/summary:
     get:
       summary: Get perp market summary

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.3
+  version: 2.3.0
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -61,6 +61,29 @@ paths:
       responses:
         '200':
           description: List of market definitions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketDefinition'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  # PRO-107: perp-prefixed alias of /marketDefinitions, mirroring the spot* naming.
+  # Same handler/response; the un-prefixed route is kept for back-compat.
+  /perpMarketDefinitions:
+    get:
+      summary: Get perp market definitions
+      description: Alias of `/marketDefinitions`, mirroring the `/spotMarketDefinitions` naming.
+      operationId: getPerpMarketDefinitions
+      tags:
+        - Reference Data
+      responses:
+        '200':
+          description: List of perp market definitions
           content:
             application/json:
               schema:
@@ -233,11 +256,55 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  # PRO-107: perp-prefixed alias of /markets/summary, mirroring the spot* naming.
+  /perpMarkets/summary:
+    get:
+      summary: Get perp market summaries
+      description: Alias of `/markets/summary`, mirroring the `/spotMarkets/summary` naming. Statistics and throttled market data for all perp markets. Recalculated every 0.5s
+      operationId: getPerpMarketsSummary
+      tags:
+        - Market Data
+      responses:
+        '200':
+          description: List of perp market summaries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /market/{symbol}/summary:
     get:
       summary: Get market summary
       description: Statistics and throttled data for a specific market. Recalculated every 0.5s
       operationId: getMarketSummary
+      tags:
+        - Market Data
+      parameters:
+        - $ref: '#/components/parameters/SymbolParam'
+      responses:
+        '200':
+          description: Market summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  # PRO-107: perp-prefixed alias of /market/{symbol}/summary, mirroring the spot* naming.
+  /perpMarket/{symbol}/summary:
+    get:
+      summary: Get perp market summary
+      description: Alias of `/market/{symbol}/summary`, mirroring the `/spotMarket/{symbol}/summary` naming. Statistics and throttled data for a specific perp market. Recalculated every 0.5s
+      operationId: getPerpMarketSummary
       tags:
         - Market Data
       parameters:

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -55,7 +55,9 @@ paths:
   /marketDefinitions:
     get:
       summary: Get market definitions
+      description: 'Deprecated: use `/perpMarketDefinitions` instead. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketDefinitions
+      deprecated: true
       tags:
         - Reference Data
       responses:
@@ -236,8 +238,9 @@ paths:
   /markets/summary:
     get:
       summary: Get market summaries
-      description: Statistics and throttled market data for all markets. Recalculated every 0.5s
+      description: 'Deprecated: use `/perpMarkets/summary` instead. Statistics and throttled market data for all markets. Recalculated every 0.5s. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketsSummary
+      deprecated: true
       tags:
         - Market Data
       responses:
@@ -278,8 +281,9 @@ paths:
   /market/{symbol}/summary:
     get:
       summary: Get market summary
-      description: Statistics and throttled data for a specific market. Recalculated every 0.5s
+      description: 'Deprecated: use `/perpMarket/{symbol}/summary` instead. Statistics and throttled data for a specific market. Recalculated every 0.5s. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketSummary
+      deprecated: true
       tags:
         - Market Data
       parameters:


### PR DESCRIPTION
## What

Documents the `perp*`-prefixed `/v2` aliases added at runtime in **reya-off-chain-monorepo#2673**, so the published OpenAPI/AsyncAPI specs (and downstream generated SDKs) expose the symmetric `perp*` names alongside the existing `spot*` ones. Integrators expect a `perp*` route/channel next to each `spot*` sibling (Linear [PRO-107](https://linear.app/reya-labs/issue/PRO-107) — Tom hit a 404 on `perpMarketDefinitions`).

### OpenAPI (`openapi-trading-v2.yaml`)
| existing (kept) | new alias | operationId |
| --- | --- | --- |
| `/marketDefinitions` | `/perpMarketDefinitions` | `getPerpMarketDefinitions` |
| `/markets/summary` | `/perpMarkets/summary` | `getPerpMarketsSummary` |
| `/market/{symbol}/summary` | `/perpMarket/{symbol}/summary` | `getPerpMarketSummary` |

### AsyncAPI (`asyncapi-trading-v2.yaml`)
| existing (kept) | new alias channel | operation |
| --- | --- | --- |
| `/v2/markets/summary` | `/v2/perpMarkets/summary` | `receivePerpMarketsSummary` |
| `/v2/market/{symbol}/summary` | `/v2/perpMarket/{symbol}/summary` | `receivePerpMarketSummary` |

## Notes
- Aliases **reuse the same response schemas / message components** as their un-prefixed siblings — identical payloads, just an alternate name.
- Un-prefixed routes/channels are **kept** for back-compat; deprecate once integrators have switched (direct rename is breaking, and perp/spot differ in field shapes elsewhere).
- **Minor version bump `2.2.3` → `2.3.0`** (purely additive).
- Validated: both specs parse; no duplicate `operationId`s; alias channel addresses correct.

## Companion
- Runtime aliases: reya-off-chain-monorepo#2673 (REST router + bun-socket WS gateway).
- After merge: regenerate downstream SDKs (Python SDK, `@reyaxyz/api-v2-sdk`) against `2.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new REST API endpoints to query perpetual market definitions and retrieve summary information for all perpetual markets or by individual symbol
  * Added new WebSocket channels to stream real-time perpetual market summary updates as they occur
  * Trading API specification updated to version 2.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->