### PR TITLE
chore: bump API specs to 2.3.4 (unblock PRO-107 submodule pin)

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.0
+  version: 2.3.4
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.0
+  version: 2.3.4
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.0
+  version: 2.3.4
   contact:
     name: Reya Network
     url: https://reya.xyz


### PR DESCRIPTION
## Why

The PRO-107 perp* alias docs (#49) merged to `main` with `info.version: 2.3.0`. But `2.3.0`–`2.3.3` were **already tagged** (on the `feat/perpOB` line), so the post-merge auto-tagger couldn't create a tag for the merge commit `9510d92` — leaving `main` **untagged**.

The monorepo's `generation-consistency` check requires the `specs` submodule to point at a **tagged** commit, so reya-off-chain-monorepo#2673 (which pins the submodule to pick up the perp aliases) is currently blocked.

## What

Bump all three specs `2.3.0 → 2.3.4` (next free version) so merging this gives `main` a clean **2.3.4** release tag the monorepo can pin to. No content change beyond the version line.

## After merge
- Confirms tag `2.3.4` is created on `main` by the post-merge-tag workflow.
- Re-pin the `specs` submodule in reya-off-chain-monorepo#2673 to the `2.3.4` tag + re-run the SDK regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API specification versions from 2.3.0 to 2.3.4 across multiple specification files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->