### PR TITLE
feat(order): add postOnly to CreateOrderRequest + GTT to TimeInForce

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.0
+  version: 3.0.1
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.0
+  version: 3.0.1
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.0
+  version: 3.0.1
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -107,8 +107,8 @@
       "$id": "#TimeInForce",
       "x-parser-schema-id": "TimeInForce",
       "type": "string",
-      "enum": ["IOC", "GTC"],
-      "description": "Order time in force (IOC = Immediate or Cancel, GTC = Good Till Cancel)",
+      "enum": ["IOC", "GTC", "GTT"],
+      "description": "Order time in force (IOC = Immediate or Cancel, GTC = Good Till Cancel, GTT = Good Till Time)",
       "example": "GTC"
     },
     "OrderType": {
@@ -1321,7 +1321,7 @@
         },
         "timeInForce": {
           "$ref": "#/definitions/TimeInForce",
-          "description": "Order time in force (exclusively used for LIMIT orders). Maps to on-chain `OrderDetails.timeInForce` (0 = GTC, 1 = IOC). This field is signed but not enforced on-chain.",
+          "description": "Order time in force (exclusively used for LIMIT orders). Maps to on-chain `OrderDetails.timeInForce` (0 = GTC, 1 = IOC, 2 = GTT). This field is signed but not enforced on-chain.",
           "example": "GTC"
         },
         "triggerPx": {
@@ -1332,6 +1332,11 @@
         "reduceOnly": {
           "type": "boolean",
           "description": "Reduce-only intent. Perp only; spot markets must set this to false. Maps to on-chain `OrderDetails.reduceOnly`.",
+          "example": false
+        },
+        "postOnly": {
+          "type": "boolean",
+          "description": "Post-only (maker-only) intent: the order must rest and never cross as a taker. Valid on GTC/GTT; rejected on IOC. Maps to on-chain `OrderDetails.postOnly`.",
           "example": false
         },
         "signature": {
@@ -1355,7 +1360,7 @@
         },
         "expiresAfter": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Unix seconds. Order lifetime — signed into `OrderDetails.expiresAfter` and enforced on-chain at execution. Optional; `0` (the default if omitted) means good-until-cancelled. When `expiresAfter > 0`, clients should ensure `deadline <= expiresAfter`.",
+          "description": "Unix seconds. Order lifetime — signed into `OrderDetails.expiresAfter` and enforced on-chain at execution. Optional; `0` (the default if omitted) means good-until-cancelled. GTC and IOC orders use `0`; only GTT orders set a non-zero `expiresAfter`, which must be greater than `deadline` (`deadline <= expiresAfter`).",
           "example": 1676923200
         },
         "clientOrderId": {


### PR DESCRIPTION
## What

Surface the new `OrderDetails.postOnly` field and the `GTT` time-in-force in the shared trading schema.

- **`CreateOrderRequest.postOnly`** (optional boolean, inserted after `reduceOnly`): maker-only intent — the order must rest and never cross as a taker. Valid on GTC/GTT, rejected on IOC. The ws-exec `createOrder` frame `$ref`s `CreateOrderRequest`, so it picks this up automatically.
- **`TimeInForce` += `GTT`** (maps to on-chain `timeInForce = 2`).
- **`expiresAfter` doc**: clarified that GTC/IOC use `0`; only GTT sets a non-zero `expiresAfter`, which must exceed `deadline`.

## Why

The on-chain `OrderDetails` struct went 13 → 14 fields (`postOnly`, inserted after `reduceOnly`) and `TimeInForce` gained `GTT`. Signing clients already produce 14-field signatures; the wire contract needs `postOnly` so order entry can carry it and the server can reconstruct the signed struct.

## Deploy note

Additive and safe to merge. ⚠️ Regenerated SDKs must ship **lockstep** with the server-side 14-field digest reconstruction — a client that sends `postOnly` before the server reconstructs 14 fields would fail signer recovery. `postOnly=false` reconstructs identically either way; only `postOnly=true` / GTT entry depend on the server side landing.

## Scope

Entry contract only. The read models (`Order` / order-change events) intentionally do **not** expose `postOnly` here — whether the order channels should surface it is a separate decision tracked elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
