### PR TITLE
fix(spec): drop deprecated /marketDefinitions (unbreaks GitBook perp render) + examples→example

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.2
+  version: 3.0.3
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.2
+  version: 3.0.3
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.2
+  version: 3.0.3
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -52,28 +52,6 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /marketDefinitions:
-    get:
-      summary: Get market definitions
-      description: 'Deprecated: use `/perpMarketDefinitions` instead. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
-      operationId: getMarketDefinitions
-      deprecated: true
-      tags:
-        - Reference Data
-      responses:
-        '200':
-          description: List of market definitions
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/MarketDefinition'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
   /perpMarketDefinitions:
     get:
       summary: Get perp market definitions

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -5,32 +5,32 @@
       "title": "Symbol",
       "type": "string",
       "pattern": "^[A-Za-z0-9]+$",
-      "examples": ["BTCRUSDPERP", "WETHRUSD"],
+      "example": "BTCRUSDPERP",
       "description": "Trading symbol (e.g., BTCRUSDPERP, WETHRUSD)"
     },
     "Asset": {
       "title": "Asset",
       "type": "string",
       "pattern": "^[A-Za-z0-9]+$",
-      "examples": ["BTCRUSDPERP", "WETHRUSD"]
+      "example": "BTCRUSDPERP"
     },
     "Address": {
       "title": "Address",
       "type": "string",
       "pattern": "^0x[a-fA-F0-9]{40}$",
-      "examples": ["0x6c51275fd01d5dbd2da194e92f920f8598306df2"]
+      "example": "0x6c51275fd01d5dbd2da194e92f920f8598306df2"
     },
     "UnsignedDecimal": {
       "title": "UnsignedDecimal",
       "type": "string",
       "pattern": "^\\d+(\\.\\d+)?([eE][+-]?\\d+)?$",
-      "examples": ["1.0", "0.001", "154.741", "1.2345e10", "6.789e-5"]
+      "example": "1.0"
     },
     "SignedDecimal": {
       "title": "SignedDecimal",
       "type": "string",
       "pattern": "^-?\\d+(\\.\\d+)?([eE][+-]?\\d+)?$",
-      "examples": ["43000.00", "2666.48162040777", "0.01", "-1250.75", "-1.12628295e-9", "3.14159e+8"]
+      "example": "43000.00"
     },
     "PriceValue": {
       "title": "PriceValue",
@@ -44,7 +44,7 @@
       "title": "UnsignedInteger",
       "type": "integer",
       "minimum": 0,
-      "examples": [1747927089946, 1756733379000]
+      "example": 1747927089946
     },
     "RequestErrorCode": {
       "title": "RequestErrorCode",


### PR DESCRIPTION
## What

`/perpMarketDefinitions` (the canonical perp route) is **missing from the published GitBook OpenAPI reference** while the deprecated `/marketDefinitions` renders. Both operations resolve to the same `MarketDefinition` response schema, and GitBook's published renderer **collapses two operations that share a response schema** — keeping the first-defined (`/marketDefinitions`, deprecated) and dropping the alias.

This removes the deprecated `/marketDefinitions` path, leaving `/perpMarketDefinitions` as the sole owner of `MarketDefinition` so it renders. The un-prefixed route still works on the API for back-compat — it's simply no longer advertised (steers integrators to `perp*`).

## Changes

- **`openapi-trading-v2.yaml`** — remove the deprecated `/marketDefinitions` path. `MarketDefinition` schema retained (`/perpMarketDefinitions` references it).
- **`trading-schemas.json`** — `examples` (plural; JSON-Schema/AsyncAPI) → `example` (singular; OpenAPI 3.0) in the 6 shared primitive schemas (`Symbol`, `Asset`, `Address`, `UnsignedDecimal`, `SignedDecimal`, `UnsignedInteger`), clearing GitBook's "examples not expected" anomalies. AsyncAPI is unaffected (`example` is ignored there; WS docs are hand-written).

## Verification

Bundled with redocly `2.0.8` (deploy parity): `/marketDefinitions` gone, `/perpMarketDefinitions` present, `MarketDefinition` schema present, **0 `$id`**, **0 plural-`examples`**, 32 paths. The `lint-spec` `$id` gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)