### PR TITLE
feat: add optional firstFillId + fillCount to Order and CreateOrderResponse

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.5
+  version: 2.3.6
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.5
+  version: 2.3.6
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.5
+  version: 2.3.6
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -424,6 +424,16 @@
           "description": "Total Executed quantity accross all fills where the order is involved.",
           "example": "0.5"
         },
+        "fillIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Matching-engine fill nonces for the fills this update represents. For a taker update, every fill the order produced in its matching round; for a maker update, its single fill. Present only on fill updates; empty/absent for non-fill updates and resting-order snapshots.",
+          "example": [
+            "7205759403792794624"
+          ]
+        },
         "side": {
           "$ref": "#/definitions/Side"
         },
@@ -1357,6 +1367,17 @@
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Client-provided order ID echoed back from the request",
           "example": "123456789"
+        },
+        "fillIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Matching-engine fill nonces for the fills this order produced immediately on entry. Empty if the order did not fill on entry. The same nonces appear on the order's taker update in the orderChanges channel.",
+          "example": [
+            "7205759403792794624",
+            "7205759403792794625"
+          ]
         }
       },
       "additionalProperties": true

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -431,6 +431,7 @@
         },
         "fillCount": {
           "type": "integer",
+          "minimum": 1,
           "description": "Number of fills this update represents — the length of the contiguous nonce range starting at firstFillId. For a taker update, the fills produced in its matching round; for a maker update, 1. Present only on fill updates; absent otherwise.",
           "example": 2
         },
@@ -1370,11 +1371,12 @@
         },
         "firstFillId": {
           "type": "string",
-          "description": "Matching-engine fill nonce of the first fill this order produced on entry. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. Absent if the order did not fill on entry. The same first nonce appears on the order's taker update in the orderChanges channel.",
+          "description": "Matching-engine fill nonce of the first fill this order produced on entry. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. Absent if the order did not fill on entry. For a resting (GTC) taker, the same first nonce also appears on the order's taker update in the orderChanges channel; an IOC taker is not published to orderChanges, so this response is the only place its fill range is delivered.",
           "example": "7205759403792794624"
         },
         "fillCount": {
           "type": "integer",
+          "minimum": 1,
           "description": "Number of fills this order produced on entry — the length of the contiguous nonce range starting at firstFillId. Absent if the order did not fill on entry.",
           "example": 2
         }

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -424,15 +424,15 @@
           "description": "Total Executed quantity accross all fills where the order is involved.",
           "example": "0.5"
         },
-        "fillIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Matching-engine fill nonces for the fills this update represents. For a taker update, every fill the order produced in its matching round; for a maker update, its single fill. Present only on fill updates; empty/absent for non-fill updates and resting-order snapshots.",
-          "example": [
-            "7205759403792794624"
-          ]
+        "firstFillId": {
+          "type": "string",
+          "description": "Matching-engine fill nonce of the first fill this update represents. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. For a taker update, the first fill of its matching round; for a maker update, its single fill. Present only on fill updates; absent for non-fill updates and resting-order snapshots.",
+          "example": "7205759403792794624"
+        },
+        "fillCount": {
+          "type": "integer",
+          "description": "Number of fills this update represents — the length of the contiguous nonce range starting at firstFillId. For a taker update, the fills produced in its matching round; for a maker update, 1. Present only on fill updates; absent otherwise.",
+          "example": 2
         },
         "side": {
           "$ref": "#/definitions/Side"
@@ -1368,16 +1368,15 @@
           "description": "Client-provided order ID echoed back from the request",
           "example": "123456789"
         },
-        "fillIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Matching-engine fill nonces for the fills this order produced immediately on entry. Empty if the order did not fill on entry. The same nonces appear on the order's taker update in the orderChanges channel.",
-          "example": [
-            "7205759403792794624",
-            "7205759403792794625"
-          ]
+        "firstFillId": {
+          "type": "string",
+          "description": "Matching-engine fill nonce of the first fill this order produced on entry. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. Absent if the order did not fill on entry. The same first nonce appears on the order's taker update in the orderChanges channel.",
+          "example": "7205759403792794624"
+        },
+        "fillCount": {
+          "type": "integer",
+          "description": "Number of fills this order produced on entry — the length of the contiguous nonce range starting at firstFillId. Absent if the order did not fill on entry.",
+          "example": 2
         }
       },
       "additionalProperties": true

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -430,9 +430,8 @@
           "example": "7205759403792794624"
         },
         "fillCount": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Number of fills this update represents — the length of the contiguous nonce range starting at firstFillId. For a taker update, the fills produced in its matching round; for a maker update, 1. Present only on fill updates; absent otherwise.",
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Number of fills this update represents — the length of the contiguous nonce range starting at firstFillId. For a taker update, the fills produced in its matching round; for a maker update, 1. Present only on fill updates; absent otherwise (so it is >= 1 whenever present).",
           "example": 2
         },
         "side": {
@@ -1375,9 +1374,8 @@
           "example": "7205759403792794624"
         },
         "fillCount": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Number of fills this order produced on entry — the length of the contiguous nonce range starting at firstFillId. Absent if the order did not fill on entry.",
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Number of fills this order produced on entry — the length of the contiguous nonce range starting at firstFillId. Absent if the order did not fill on entry (so it is >= 1 whenever present).",
           "example": 2
         }
       },

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -1370,7 +1370,7 @@
         },
         "firstFillId": {
           "type": "string",
-          "description": "Matching-engine fill nonce of the first fill this order produced on entry. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. Absent if the order did not fill on entry. For a resting (GTC) taker, the same first nonce also appears on the order's taker update in the orderChanges channel; an IOC taker is not published to orderChanges, so this response is the only place its fill range is delivered.",
+          "description": "Matching-engine fill nonce of the first fill this order produced on entry. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. Absent if the order did not fill on entry. For a non-IOC (resting) taker, the same first nonce also appears on the order's taker update in the orderChanges channel; an IOC taker is not published to orderChanges, so this response is the only place its fill range is delivered.",
           "example": "7205759403792794624"
         },
         "fillCount": {


### PR DESCRIPTION
## What

Adds an optional **`{firstFillId, fillCount}`** fill-nonce range to two schemas in `trading-schemas.json`:
- **`Order`** (the payload of the `orderChanges` WS channel) — the matching-engine fills an update represents.
- **`CreateOrderResponse`** — the fills an order produced immediately on entry.

## Shape

`firstFillId` (`string`) + `fillCount` (`integer`), both optional (not in `required`).

ME fill nonces within one matching round are **contiguous** (one ME-wide shared generator advanced once per fill under a frozen per-round timestamp), so the fills are exactly the range `[firstFillId, firstFillId + fillCount - 1]`. This is O(1) regardless of how many resting orders a taker crosses — replacing the earlier unbounded `fillIds` array, which could grow without limit on a deep sweep.

`firstFillId` is a string because the nonce is a Snowflake `u64` that overflows the JS safe-integer range — consistent with how `orderId` and the request `nonce` are typed. Both fields are omitted for non-fill updates and resting-order snapshots.

- **Taker** update / `CreateOrderResponse` → `firstFillId` = the round's first fill nonce, `fillCount` = number of fills.
- **Maker** update → its single fill (`fillCount = 1`).

`{firstFillId, fillCount}` is the join key that will let a fill seen in `orderChanges`/`createOrder` be matched to the same fill in the execution/bust channels later.

## Validation

`redocly lint` reports the same 87 pre-existing errors / 3 warnings as `origin/main` — **zero new problems**, none referencing the new fields.

## Cross-repo

Part of a 3-PR additive change. The ME emits the range on the Redis order-change stream (Reya-Labs/reya-chain#162); the off-chain backend surfaces it on `orderChanges` + `createOrder` (Reya-Labs/reya-off-chain-monorepo#2735). Consumed via the `specs` submodule + `generate-unified-sdk.sh` after this merges and is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
