### PR TITLE
fix: revert market status

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.3.7
+  version: 2.3.8
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.3.7
+  version: 2.3.8
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.3.7
+  version: 2.3.8
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -853,8 +853,7 @@
         "liquidationMarginParameter",
         "initialMarginParameter",
         "maxLeverage",
-        "oiCap",
-        "status"
+        "oiCap"
       ],
       "properties": {
         "symbol": {
@@ -898,12 +897,6 @@
           "$ref": "#/definitions/UnsignedDecimal",
           "description": "Maximum one-sided open interest in units for a given market.",
           "example": "10000"
-        },
-        "status": {
-          "type": "string",
-          "enum": ["TRADING", "REDUCE_ONLY", "SETTLED"],
-          "description": "Trading status of the market, derived from open interest and the open interest cap (TRADING = open for trading, REDUCE_ONLY = positions may only be reduced, SETTLED = market has been settled).",
-          "example": "TRADING"
         }
       },
       "additionalProperties": true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Bumped API document versions from 2.3.7 to 2.3.8 across the published specs.
* **Bug Fixes**
  * Updated the market definition schema to no longer require the `status` field.
  * Removed the `status` field from the market definition contract, simplifying the data shape returned to clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->