### PR TITLE
[codex] Merge main specs into spot order history

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 2.2.7
+  version: 2.3.8
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing and cancelling orders over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 2.2.7
+  version: 2.3.8
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network
@@ -60,17 +60,37 @@ channels:
 
   marketsSummary:
     address: /v2/markets/summary
-    description: Real-time updates for all market summaries
+    description: 'Deprecated: use `/v2/perpMarkets/summary` instead. Real-time updates for all market summaries. This un-prefixed channel still works but will be removed once integrators have migrated to the `perp*` naming. (AsyncAPI 3.0 has no native `deprecated` field on channels; flagged via `x-deprecated`.)'
+    x-deprecated: true
     messages:
       marketsSummaryUpdate:
         $ref: '#/components/messages/MarketsSummaryUpdate'
 
   marketSummary:
     address: /v2/market/{symbol}/summary
-    description: Real-time updates for a specific market's summary
+    description: 'Deprecated: use `/v2/perpMarket/{symbol}/summary` instead. Real-time updates for a specific market''s summary. This un-prefixed channel still works but will be removed once integrators have migrated to the `perp*` naming. (AsyncAPI 3.0 has no native `deprecated` field on channels; flagged via `x-deprecated`.)'
+    x-deprecated: true
     parameters:
       symbol:
         description: Trading symbol (e.g., BTCRUSDPERP, ETHRUSD)
+        location: $message.payload#/symbol
+    messages:
+      marketSummaryUpdate:
+        $ref: '#/components/messages/MarketSummaryUpdate'
+
+  perpMarketsSummary:
+    address: /v2/perpMarkets/summary
+    description: Alias of `/v2/markets/summary` (mirrors `/v2/spotMarkets/summary`). Real-time updates for all perp market summaries
+    messages:
+      marketsSummaryUpdate:
+        $ref: '#/components/messages/MarketsSummaryUpdate'
+
+  perpMarketSummary:
+    address: /v2/perpMarket/{symbol}/summary
+    description: Alias of `/v2/market/{symbol}/summary` (mirrors `/v2/spotMarket/{symbol}/summary`). Real-time updates for a specific perp market's summary
+    parameters:
+      symbol:
+        description: Trading symbol (e.g., BTCRUSDPERP)
         location: $message.payload#/symbol
     messages:
       marketSummaryUpdate:
@@ -306,7 +326,8 @@ operations:
       $ref: '#/channels/marketsSummary'
     messages:
       - $ref: '#/channels/marketsSummary/messages/marketsSummaryUpdate'
-    summary: Receive market summaries updates
+    summary: 'Deprecated: use receivePerpMarketsSummary instead. Receive market summaries updates.'
+    x-deprecated: true
 
   receiveMarketSummary:
     action: receive
@@ -314,7 +335,24 @@ operations:
       $ref: '#/channels/marketSummary'
     messages:
       - $ref: '#/channels/marketSummary/messages/marketSummaryUpdate'
-    summary: Receive specific market summary updates
+    summary: 'Deprecated: use receivePerpMarketSummary instead. Receive specific market summary updates.'
+    x-deprecated: true
+
+  receivePerpMarketsSummary:
+    action: receive
+    channel:
+      $ref: '#/channels/perpMarketsSummary'
+    messages:
+      - $ref: '#/channels/perpMarketsSummary/messages/marketsSummaryUpdate'
+    summary: Receive perp market summaries updates (alias of receiveMarketsSummary)
+
+  receivePerpMarketSummary:
+    action: receive
+    channel:
+      $ref: '#/channels/perpMarketSummary'
+    messages:
+      - $ref: '#/channels/perpMarketSummary/messages/marketSummaryUpdate'
+    summary: Receive specific perp market summary updates (alias of receiveMarketSummary)
 
   receiveSpotMarketsSummary:
     action: receive

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 2.2.7
+  version: 2.3.8
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -55,12 +55,35 @@ paths:
   /marketDefinitions:
     get:
       summary: Get market definitions
+      description: 'Deprecated: use `/perpMarketDefinitions` instead. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketDefinitions
+      deprecated: true
       tags:
         - Reference Data
       responses:
         '200':
           description: List of market definitions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketDefinition'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /perpMarketDefinitions:
+    get:
+      summary: Get perp market definitions
+      description: Alias of `/marketDefinitions`, mirroring the `/spotMarketDefinitions` naming.
+      operationId: getPerpMarketDefinitions
+      tags:
+        - Reference Data
+      responses:
+        '200':
+          description: List of perp market definitions
           content:
             application/json:
               schema:
@@ -215,8 +238,9 @@ paths:
   /markets/summary:
     get:
       summary: Get market summaries
-      description: Statistics and throttled market data for all markets. Recalculated every 0.5s
+      description: 'Deprecated: use `/perpMarkets/summary` instead. Statistics and throttled market data for all markets. Recalculated every 0.5s. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketsSummary
+      deprecated: true
       tags:
         - Market Data
       responses:
@@ -233,11 +257,54 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /perpMarkets/summary:
+    get:
+      summary: Get perp market summaries
+      description: Alias of `/markets/summary`, mirroring the `/spotMarkets/summary` naming. Statistics and throttled market data for all perp markets. Recalculated every 0.5s
+      operationId: getPerpMarketsSummary
+      tags:
+        - Market Data
+      responses:
+        '200':
+          description: List of perp market summaries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /market/{symbol}/summary:
     get:
       summary: Get market summary
-      description: Statistics and throttled data for a specific market. Recalculated every 0.5s
+      description: 'Deprecated: use `/perpMarket/{symbol}/summary` instead. Statistics and throttled data for a specific market. Recalculated every 0.5s. This un-prefixed route still works but will be removed once integrators have migrated to the `perp*` naming.'
       operationId: getMarketSummary
+      deprecated: true
+      tags:
+        - Market Data
+      parameters:
+        - $ref: '#/components/parameters/SymbolParam'
+      responses:
+        '200':
+          description: Market summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /perpMarket/{symbol}/summary:
+    get:
+      summary: Get perp market summary
+      description: Alias of `/market/{symbol}/summary`, mirroring the `/spotMarket/{symbol}/summary` naming. Statistics and throttled data for a specific perp market. Recalculated every 0.5s
+      operationId: getPerpMarketSummary
       tags:
         - Market Data
       parameters:
@@ -305,6 +372,7 @@ paths:
         - $ref: '#/components/parameters/SymbolParam'
         - $ref: '#/components/parameters/StartTimeParam'
         - $ref: '#/components/parameters/EndTimeParam'
+        - $ref: '#/components/parameters/ExecutionTypeParam'
       responses:
         '200':
           description: List of perp executions
@@ -463,6 +531,7 @@ paths:
         - $ref: '#/components/parameters/AddressParam'
         - $ref: '#/components/parameters/StartTimeParam'
         - $ref: '#/components/parameters/EndTimeParam'
+        - $ref: '#/components/parameters/ExecutionTypeParam'
       responses:
         '200':
           description: List of perpetual executions
@@ -722,7 +791,10 @@ components:
       name: startTime
       in: query
       required: false
-      description: Return results at or after this timestamp, in milliseconds (for pagination)
+      description: >-
+        Return results at or after this time (inclusive lower bound).
+        Millisecond POSIX timestamp, matched against each execution's on-chain
+        block timestamp.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733379000
@@ -731,10 +803,27 @@ components:
       name: endTime
       in: query
       required: false
-      description: Return results at or before this timestamp, in milliseconds (for pagination)
+      description: >-
+        Return results at or before this time (inclusive upper bound).
+        Millisecond POSIX timestamp, matched against each execution's on-chain
+        block timestamp. Results are returned newest-first and capped at a
+        maximum that varies by endpoint; to page backward through history,
+        pass the oldest timestamp from the previous page.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000
+
+    ExecutionTypeParam:
+      name: type
+      in: query
+      required: false
+      description: Filter perp executions by type. Omit to return executions of all types.
+      schema:
+        type: string
+        enum:
+          - ORDER_MATCH
+          - LIQUIDATION
+        example: LIQUIDATION
 
     ResolutionParam:
       name: resolution

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -426,6 +426,16 @@
           "description": "Total Executed quantity accross all fills where the order is involved.",
           "example": "0.5"
         },
+        "firstFillId": {
+          "type": "string",
+          "description": "Matching-engine fill nonce of the first fill this update represents. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. For a taker update, the first fill of its matching round; for a maker update, its single fill. Present only on fill updates; absent for non-fill updates and resting-order snapshots.",
+          "example": "7205759403792794624"
+        },
+        "fillCount": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Number of fills this update represents — the length of the contiguous nonce range starting at firstFillId. For a taker update, the fills produced in its matching round; for a maker update, 1. Present only on fill updates; absent otherwise (so it is >= 1 whenever present).",
+          "example": 2
+        },
         "side": {
           "$ref": "#/definitions/Side"
         },
@@ -1411,6 +1421,16 @@
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Client-provided order ID echoed back from the request",
           "example": "123456789"
+        },
+        "firstFillId": {
+          "type": "string",
+          "description": "Matching-engine fill nonce of the first fill this order produced on entry. Together with fillCount it identifies the fills as a contiguous nonce range [firstFillId, firstFillId + fillCount - 1]. Absent if the order did not fill on entry. For a non-IOC (resting) taker, the same first nonce also appears on the order's taker update in the orderChanges channel; an IOC taker is not published to orderChanges, so this response is the only place its fill range is delivered.",
+          "example": "7205759403792794624"
+        },
+        "fillCount": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Number of fills this order produced on entry — the length of the contiguous nonce range starting at firstFillId. Absent if the order did not fill on entry (so it is >= 1 whenever present).",
+          "example": 2
         }
       },
       "additionalProperties": true
@@ -1426,12 +1446,12 @@
       "properties": {
         "orderId": {
           "type": "string",
-          "description": "Internal matching engine order ID to cancel. Provide either orderId OR clientOrderId, not both. For spot markets, this is the order ID returned in the CreateOrderResponse.",
+          "description": "Internal matching engine order ID to cancel. At least one of `orderId` or `clientOrderId` must be provided; if both are supplied the server treats `orderId` as the canonical identifier and `clientOrderId` is ignored. For spot markets, this is the order ID returned in the CreateOrderResponse.",
           "example": "490346525705109504"
         },
         "clientOrderId": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Client-provided order ID for tracking and correlation. Provide either orderId OR clientOrderId, not both. This is the same clientOrderId provided in CreateOrderRequest.",
+          "description": "Client-provided order ID for tracking and correlation. At least one of `orderId` or `clientOrderId` must be provided; `clientOrderId` is consulted only when `orderId` is absent. This is the same clientOrderId provided in CreateOrderRequest.",
           "example": "123456789"
         },
         "accountId": {


### PR DESCRIPTION
## Summary

- Merge current `main` API spec changes into `feat/spot-order-history`.
- Keep the order-history additions from the feature branch and the `firstFillId` / `fillCount` order fields from main.
- Resolve spec version header conflicts to `2.3.8`.

## Notes

This PR exists so the off-chain submodule update can reference a fetchable specs commit while the off-chain PR targets `feat/spot-order-history`.