### PR TITLE
fix(spec): cumQty 'accross' typo + ExecutionBust sequenceNumber wording

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.7
+  version: 3.0.8
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.7
+  version: 3.0.8
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.7
+  version: 3.0.8
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -387,7 +387,7 @@
         },
         "cumQty": {
           "$ref": "#/definitions/Qty",
-          "description": "Total Executed quantity accross all fills where the order is involved.",
+          "description": "Total Executed quantity across all fills where the order is involved.",
           "example": "0.5"
         },
         "firstFillId": {
@@ -827,7 +827,7 @@
         },
         "sequenceNumber": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Execution sequence number, increases by 1 for every spot execution bust in reya chain",
+          "description": "Execution sequence number, increases by 1 for every execution bust in reya chain",
           "example": 152954
         },
         "fillId": {
@@ -1385,7 +1385,7 @@
         },
         "cumQty": {
           "$ref": "#/definitions/Qty",
-          "description": "Total Executed quantity accross all fills where the order is involved.",
+          "description": "Total Executed quantity across all fills where the order is involved.",
           "example": "0.5"
         },
         "orderId": {


### PR DESCRIPTION
From the post-merge perpOB V2 spec audit — two trivial wording fixes in `trading-schemas.json`:

- **`accross` → `across`** (×2) in `Order.cumQty` and `CreateOrderResponse.cumQty` descriptions (already spelled correctly on `ModifyOrderResponse`).
- **`ExecutionBust.sequenceNumber`**: drop the word **`spot`** — the description said *"every **spot** execution bust"* but `ExecutionBust` serves **both** spot and perp busts (its own `symbol` field documents both `*RUSD` and `*RUSDPERP`, and the bust endpoints cover both).

No schema/shape change — descriptions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)