### PR TITLE
feat: add perpOB order history spec

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.11
+  version: 3.0.12
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.11
+  version: 3.0.12
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.11
+  version: 3.0.12
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -510,6 +510,52 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /wallet/{address}/orderHistory:
+    get:
+      summary: Get wallet order history
+      description: |
+        Returns up to 100 historical matching-engine order state updates for a
+        wallet, newest first. Each row is one public `Order` projection emitted
+        by the matching engine for one of the wallet's accounts, covering both
+        spot and perp markets once the matching-engine order-history writer is
+        enabled for the environment.
+
+        This endpoint is for retail/account-history views and support tooling.
+        It is not intended for market-maker ingestion, audit logs, or
+        high-throughput reconciliation. The backing service stores bounded
+        history per account and can automatically exclude high-throughput
+        accounts from persistence; market makers should capture their own
+        durable order timeline from the `orderChanges` WebSocket stream.
+
+        Pagination follows the same descending time-window convention as the
+        wallet execution endpoints. `startTime` and `endTime` are millisecond
+        POSIX timestamps matched against each row's matching-engine event time
+        (`lastUpdateAt`). Results are returned newest-first; `meta.startTime`
+        is the newest returned row timestamp and `meta.endTime` is the oldest
+        returned row timestamp. Because `endTime` is an inclusive upper bound,
+        clients that pass the previous `meta.endTime` may receive boundary
+        rows again and should deduplicate overlap. Clients that do not need to
+        preserve same-millisecond boundary ties may page backward with
+        `endTime = meta.endTime - 1`.
+      operationId: getWalletOrderHistory
+      tags:
+        - Wallet Data
+      parameters:
+        - $ref: '#/components/parameters/AddressParam'
+        - $ref: '#/components/parameters/StartTimeParam'
+        - $ref: '#/components/parameters/EndTimeParam'
+      responses:
+        '200':
+          description: Paginated list of order state updates
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderHistoryList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /wallet/{address}/positions:
     get:
       summary: Get wallet positions
@@ -807,8 +853,10 @@ components:
       required: false
       description: >-
         Return results at or after this time (inclusive lower bound).
-        Millisecond POSIX timestamp, matched against each execution's on-chain
-        block timestamp.
+        Millisecond POSIX timestamp, matched against the endpoint's record
+        timestamp. Execution and bust endpoints use on-chain block timestamps;
+        orderHistory uses the matching-engine event timestamp exposed as
+        `lastUpdateAt`.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733379000
@@ -819,10 +867,14 @@ components:
       required: false
       description: >-
         Return results at or before this time (inclusive upper bound).
-        Millisecond POSIX timestamp, matched against each execution's on-chain
-        block timestamp. Results are returned newest-first and capped at a
-        maximum that varies by endpoint; to page backward through history,
-        pass the oldest timestamp from the previous page.
+        Millisecond POSIX timestamp, matched against the endpoint's record
+        timestamp. Execution and bust endpoints use on-chain block timestamps;
+        orderHistory uses the matching-engine event timestamp exposed as
+        `lastUpdateAt`. Results are returned newest-first and capped at a
+        maximum that varies by endpoint. Because this bound is inclusive,
+        passing the oldest timestamp from the previous page can repeat boundary
+        rows; clients should deduplicate overlap or subtract 1ms when same-ms
+        boundary ties are not relevant.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000
@@ -885,6 +937,9 @@ components:
 
     Order:
       $ref: './trading-schemas.json#/definitions/Order'
+
+    OrderHistoryList:
+      $ref: './trading-schemas.json#/definitions/OrderHistoryList'
 
     Account:
       $ref: './trading-schemas.json#/definitions/Account'

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -446,7 +446,7 @@
         },
         "lastUpdateAt": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Last update timestamp (milliseconds)",
+          "description": "Last update timestamp in milliseconds. For orderChanges WebSocket events and orderHistory REST rows this is the matching-engine event timestamp used by orderHistory startTime/endTime filters.",
           "example": 1747927089946
         },
         "cancelReason": {
@@ -457,6 +457,26 @@
           "type": "string",
           "description": "Human-readable explanation of `cancelReason`. Present only when `cancelReason` is present.",
           "example": "Order cancelled because it would have matched your own resting order"
+        }
+      },
+      "additionalProperties": true
+    },
+    "OrderHistoryList": {
+      "title": "OrderHistoryList",
+      "type": "object",
+      "required": [
+        "data",
+        "meta"
+      ],
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Order"
+          }
+        },
+        "meta": {
+          "$ref": "#/definitions/PaginationMeta"
         }
       },
       "additionalProperties": true
@@ -2290,12 +2310,12 @@
         },
         "endTime": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Timestamp of last result, in milliseconds",
+          "description": "Timestamp of the last result in response order, in milliseconds. Descending endpoints return newest-first, so this is the oldest returned timestamp and can be used as the next page's endTime boundary.",
           "example": 1756733679000
         },
         "startTime": {
           "$ref": "#/definitions/UnsignedInteger",
-          "description": "Timestamp of first result, in milliseconds",
+          "description": "Timestamp of the first result in response order, in milliseconds. Descending endpoints return newest-first, so this is the newest returned timestamp.",
           "example": 1756733579000
         }
       },


### PR DESCRIPTION
## Summary
- add GET /wallet/{address}/orderHistory to the perpOB OpenAPI spec
- document the implementation's startTime/endTime behavior: millisecond matching-engine event timestamps, inclusive bounds, newest-first rows, meta.startTime as newest and meta.endTime as oldest
- document the endpoint's intended audience: retail/account-history and support tooling, not market-maker ingestion; high-throughput accounts may be excluded and market makers should use orderChanges

## Notes
- API code in the off-chain orderHistory PR already matches the existing wallet execution endpoint convention, so this PR only updates specs/docs.
- The previous feat/spot-order-history spec branch is stale for perpOB: it targets main and documents sequenceNumber/dedup behavior that does not match the current Order projection.

## Validation
- node -e "JSON.parse(require('fs').readFileSync('trading-schemas.json','utf8')); console.log('json ok')"
- npx --yes @redocly/cli@2.0.8 bundle openapi-trading-v2.yaml -o /tmp/openapi-bundled-orderhistory.yaml
- grep no bundled `$id` keys
- npx --yes @asyncapi/cli@1.7.0 validate asyncapi-trading-v2.yaml
- npx --yes @asyncapi/cli@1.7.0 validate asyncapi-exec-v2.yaml
- npx --yes @redocly/cli@2.0.8 lint openapi-trading-v2.yaml (informational workflow step; existing security-defined findings remain)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new wallet order-history endpoint to retrieve paginated order history results.
  * Introduced a new paginated order-history response format.

* **Documentation**
  * Updated API version numbers to 3.0.12.
  * Clarified time-based filtering and pagination guidance for order-history and related timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->