### PR TITLE
feat: add order sequence cursors

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.12
+  version: 3.0.13
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.12
+  version: 3.0.13
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network
@@ -140,12 +140,23 @@ channels:
 
   walletOrderChanges:
     address: /v2/wallet/{address}/orderChanges
-    description: Real-time order change updates for wallet
+    description: |
+      Real-time order change updates for a wallet.
+
+      Two server-to-client message types arrive on this logical channel:
+      `orderChangesSubscribed` is the initial `subscribed` confirmation and
+      carries an `OrderChangesSnapshot` payload (current open orders plus a
+      `snapshotSequenceNumber` cursor); `orderChangeUpdate` is every subsequent
+      `channel_data` frame and carries order rows whose `sequenceNumber` is
+      greater than `snapshotSequenceNumber`. The cursor lets clients splice the
+      live feed against the `/wallet/{address}/orderHistory` REST endpoint.
     parameters:
       address:
         description: Ethereum wallet address
         location: $message.payload#/address
     messages:
+      orderChangesSubscribed:
+        $ref: '#/components/messages/OrderChangesSubscribed'
       orderChangeUpdate:
         $ref: '#/components/messages/OrderChangeUpdate'
 
@@ -366,6 +377,7 @@ operations:
     channel:
       $ref: '#/channels/walletOrderChanges'
     messages:
+      - $ref: '#/channels/walletOrderChanges/messages/orderChangesSubscribed'
       - $ref: '#/channels/walletOrderChanges/messages/orderChangeUpdate'
     summary: Receive order change updates for wallet
 
@@ -485,6 +497,16 @@ components:
       summary: Real-time order change update for a wallet
       payload:
         $ref: '#/components/schemas/OrderChangeUpdatePayload'
+
+    OrderChangesSubscribed:
+      name: subscribed
+      title: Order Changes Subscribed
+      summary: |
+        Initial `subscribed` confirmation for the orderChanges channel. The
+        envelope is the generic subscribe-response shape; `contents` carries the
+        typed `OrderChangesSnapshot` payload.
+      payload:
+        $ref: '#/components/schemas/OrderChangesSubscribedPayload'
 
     MarketPerpExecutionUpdate:
       name: marketPerpExecutionUpdate
@@ -871,6 +893,22 @@ components:
           title: OrderList
           items:
             $ref: './trading-schemas.json#/definitions/Order'
+
+    OrderChangesSubscribedPayload:
+      type: object
+      title: OrderChangesSubscribedPayload
+      additionalProperties: false
+      required:
+        - type
+        - channel
+        - contents
+      properties:
+        type:
+          $ref: '#/components/schemas/SubscribedMessageType'
+        channel:
+          $ref: '#/components/schemas/WalletOrderChangesChannelPattern'
+        contents:
+          $ref: './trading-schemas.json#/definitions/OrderChangesSnapshot'
 
     MarketPerpExecutionUpdateBody:
       type: object

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -873,8 +873,8 @@ components:
         `lastUpdateAt`. Results are returned newest-first and capped at a
         maximum that varies by endpoint. Because this bound is inclusive,
         passing the oldest timestamp from the previous page can repeat boundary
-        rows. For orderHistory, deduplicate overlap by `Order.sequenceNumber`;
-        otherwise subtract 1ms when same-ms boundary ties are not relevant.
+        rows; clients can deduplicate overlap or subtract 1ms when same-ms
+        boundary ties are not relevant.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.12
+  version: 3.0.13
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -534,9 +534,9 @@ paths:
         is the newest returned row timestamp and `meta.endTime` is the oldest
         returned row timestamp. Because `endTime` is an inclusive upper bound,
         clients that pass the previous `meta.endTime` may receive boundary
-        rows again and should deduplicate overlap. Clients that do not need to
-        preserve same-millisecond boundary ties may page backward with
-        `endTime = meta.endTime - 1`.
+        rows again and should deduplicate overlap by `Order.sequenceNumber`.
+        Clients that do not need to preserve same-millisecond boundary ties may
+        page backward with `endTime = meta.endTime - 1`.
       operationId: getWalletOrderHistory
       tags:
         - Wallet Data
@@ -873,8 +873,8 @@ components:
         `lastUpdateAt`. Results are returned newest-first and capped at a
         maximum that varies by endpoint. Because this bound is inclusive,
         passing the oldest timestamp from the previous page can repeat boundary
-        rows; clients should deduplicate overlap or subtract 1ms when same-ms
-        boundary ties are not relevant.
+        rows. For orderHistory, deduplicate overlap by `Order.sequenceNumber`;
+        otherwise subtract 1ms when same-ms boundary ties are not relevant.
       schema:
         $ref: './trading-schemas.json#/definitions/UnsignedInteger'
         example: 1756733679000

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -344,6 +344,7 @@
     "Order": {
       "title": "Order",
       "type": "object",
+      "description": "Represents a state of an order. Emitted as openOrders snapshots, orderChanges WS events, and orderHistory REST rows. For event-style emissions (orderChanges WS, orderHistory REST), `lastUpdateAt` reflects the matching-engine event time and a single order produces one row per state transition (OPEN, PARTIALLY_FILLED, FILLED, CANCELLED, REJECTED). Event-style emissions include `sequenceNumber`; resting snapshots omit it.",
       "required": [
         "exchangeId",
         "symbol",
@@ -371,6 +372,11 @@
         "orderId": {
           "type": "string",
           "example": "490346525705109504"
+        },
+        "sequenceNumber": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Monotonic matching-engine order-event sequence. Present on orderHistory REST rows and orderChanges WS event rows; omitted on openOrders and other resting-order snapshots. Use it to deduplicate inclusive orderHistory page-boundary overlap and to splice orderHistory with the orderChanges live stream.",
+          "example": 152954
         },
         "clientOrderId": {
           "type": "string",
@@ -457,6 +463,32 @@
           "type": "string",
           "description": "Human-readable explanation of `cancelReason`. Present only when `cancelReason` is present.",
           "example": "Order cancelled because it would have matched your own resting order"
+        }
+      },
+      "additionalProperties": true
+    },
+    "OrderChangesSnapshot": {
+      "title": "OrderChangesSnapshot",
+      "$id": "#OrderChangesSnapshot",
+      "x-parser-schema-id": "OrderChangesSnapshot",
+      "type": "object",
+      "description": "Initial payload returned in the `subscribed` confirmation for the `/v2/wallet/{address}/orderChanges` WS channel. Combines the current open-orders snapshot with a `snapshotSequenceNumber` cursor; subsequent orderChanges WS messages carry orders with a greater `sequenceNumber`, so clients can splice the live feed against the orderHistory REST endpoint.",
+      "required": [
+        "data",
+        "snapshotSequenceNumber"
+      ],
+      "properties": {
+        "data": {
+          "type": "array",
+          "description": "Current open-orders snapshot. Snapshot orders do not include `sequenceNumber`; the snapshot boundary is represented by `snapshotSequenceNumber`.",
+          "items": {
+            "$ref": "#/definitions/Order"
+          }
+        },
+        "snapshotSequenceNumber": {
+          "$ref": "#/definitions/UnsignedInteger",
+          "description": "Matching-engine order-event sequence at which the snapshot was taken. Subsequent orderChanges WS messages on this subscription have `Order.sequenceNumber` greater than this cursor.",
+          "example": 152954
         }
       },
       "additionalProperties": true

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -344,7 +344,7 @@
     "Order": {
       "title": "Order",
       "type": "object",
-      "description": "Represents a state of an order. Emitted as openOrders snapshots, orderChanges WS events, and orderHistory REST rows. For event-style emissions (orderChanges WS, orderHistory REST), `lastUpdateAt` reflects the matching-engine event time and a single order produces one row per state transition (OPEN, PARTIALLY_FILLED, FILLED, CANCELLED, REJECTED). Event-style emissions include `sequenceNumber`; resting snapshots omit it.",
+      "description": "Represents a public order state. Emitted as openOrders snapshots, orderChanges WS events, and orderHistory REST rows. For event-style emissions (orderChanges WS, orderHistory REST), `lastUpdateAt` reflects the matching-engine event time and a single order may produce multiple rows as it moves through the public `OPEN`, `FILLED`, and `CANCELLED` statuses. Matching-engine partial-fill states surface as `OPEN`; request-level rejects are returned as errors rather than order-status rows. Event-style emissions include `sequenceNumber`; resting snapshots omit it.",
       "required": [
         "exchangeId",
         "symbol",
@@ -469,8 +469,6 @@
     },
     "OrderChangesSnapshot": {
       "title": "OrderChangesSnapshot",
-      "$id": "#OrderChangesSnapshot",
-      "x-parser-schema-id": "OrderChangesSnapshot",
       "type": "object",
       "description": "Initial payload returned in the `subscribed` confirmation for the `/v2/wallet/{address}/orderChanges` WS channel. Combines the current open-orders snapshot with a `snapshotSequenceNumber` cursor; subsequent orderChanges WS messages carry orders with a greater `sequenceNumber`, so clients can splice the live feed against the orderHistory REST endpoint.",
       "required": [


### PR DESCRIPTION
## Summary
- add optional `Order.sequenceNumber` for orderHistory REST rows and orderChanges WS event rows
- add typed `OrderChangesSnapshot` subscribe payload with `snapshotSequenceNumber`
- document sequence-based dedupe for inclusive orderHistory pagination overlap
- bump spec entrypoints to `3.0.13`

## Validation
- `jq empty trading-schemas.json`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "yaml ok"' openapi-trading-v2.yaml asyncapi-trading-v2.yaml asyncapi-exec-v2.yaml`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added initial subscription snapshot details for wallet order change updates, including a cursor to continue live updates seamlessly.
  * Expanded order data to include a sequence number for better pagination and update tracking across history and streaming views.

* **Bug Fixes**
  * Refined order history pagination guidance to reduce overlaps at time boundaries and improve duplicate handling.

* **Chores**
  * Updated API and schema document versions to `3.0.13`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->