### PR TITLE
Remove legacy price endpoints

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.13
+  version: 3.0.14
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.13
+  version: 3.0.14
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network
@@ -215,26 +215,6 @@ channels:
       accountBalanceUpdate:
         $ref: '#/components/messages/AccountBalanceUpdate'
 
-  prices:
-    address: /v2/prices
-    description: 'Deprecated: AMM-era mixed market/collateral price updates with legacy `poolPrice` semantics. Use `/v2/assetOraclePrices` for asset Stork oracle prices. Use market summary/depth channels for market prices.'
-    x-deprecated: true
-    messages:
-      pricesUpdate:
-        $ref: '#/components/messages/PricesUpdate'
-
-  price:
-    address: /v2/prices/{symbol}
-    description: 'Deprecated: AMM-era mixed market/collateral price updates with legacy `poolPrice` semantics. Use `/v2/assetOraclePrices` for asset Stork oracle prices. Use market summary/depth channels for market prices.'
-    x-deprecated: true
-    parameters:
-      symbol:
-        description: Trading symbol (e.g., BTCRUSDPERP, ETHRUSD)
-        location: $message.payload#/symbol
-    messages:
-      priceUpdate:
-        $ref: '#/components/messages/PriceUpdate'
-
   assetOraclePrices:
     address: /v2/assetOraclePrices
     description: Asset Stork oracle price updates. This replacement feed deliberately omits AMM-era `poolPrice`.
@@ -421,26 +401,6 @@ operations:
       - $ref: '#/channels/walletAccountBalances/messages/accountBalanceUpdate'
     summary: Receive account balance updates for wallet
 
-  receivePrices:
-    action: receive
-    description: 'Deprecated: use `receiveAssetOraclePrices` (`/v2/assetOraclePrices`) instead.'
-    x-deprecated: true
-    channel:
-      $ref: '#/channels/prices'
-    messages:
-      - $ref: '#/channels/prices/messages/pricesUpdate'
-    summary: Receive deprecated price updates for all symbols
-
-  receivePrice:
-    action: receive
-    description: 'Deprecated: use `receiveAssetOraclePrices` (`/v2/assetOraclePrices`) instead.'
-    x-deprecated: true
-    channel:
-      $ref: '#/channels/price'
-    messages:
-      - $ref: '#/channels/price/messages/priceUpdate'
-    summary: Receive deprecated price updates for a specific symbol
-
   receiveAssetOraclePrices:
     action: receive
     channel:
@@ -563,20 +523,6 @@ components:
       summary: Real-time account balance update for wallet
       payload:
         $ref: '#/components/schemas/AccountBalanceUpdatePayload'
-
-    PricesUpdate:
-      name: pricesUpdate
-      title: Prices Update
-      summary: Real-time price updates for all symbols
-      payload:
-        $ref: '#/components/schemas/PricesUpdatePayload'
-
-    PriceUpdate:
-      name: priceUpdate
-      title: Price Update
-      summary: Real-time price update for a specific symbol
-      payload:
-        $ref: '#/components/schemas/PriceUpdatePayload'
 
     AssetOraclePricesUpdate:
       name: assetOraclePricesUpdate
@@ -704,13 +650,6 @@ components:
         - /v2/perpMarkets/summary
       description: Channel for all perp market summary updates.
 
-    DeprecatedPricesChannel:
-      type: string
-      enum:
-        - /v2/prices
-      description: 'Deprecated legacy price channel. Use `/v2/assetOraclePrices`.'
-      x-deprecated: true
-
     AssetOraclePricesChannel:
       type: string
       enum:
@@ -782,12 +721,6 @@ components:
       type: string
       pattern: '^/v2/wallet/0x[a-fA-F0-9]{40}/accountBalances$'
       description: Channel pattern for wallet account balances
-
-    DeprecatedPriceChannelPattern:
-      type: string
-      pattern: '^/v2/prices/[A-Za-z0-9]+$'
-      description: 'Deprecated legacy price channel pattern. Use `/v2/assetOraclePrices`.'
-      x-deprecated: true
 
     BaseUpdateEnvelope:
       type: object
@@ -1035,35 +968,6 @@ components:
           items:
             $ref: './trading-schemas.json#/definitions/AccountBalance'
 
-    PricesUpdateBody:
-      type: object
-      title: PricesUpdateBody
-      additionalProperties: false
-      required:
-        - channel
-        - data
-      properties:
-        channel:
-          $ref: '#/components/schemas/DeprecatedPricesChannel'
-        data:
-          type: array
-          title: PriceList
-          items:
-            $ref: './trading-schemas.json#/definitions/Price'
-
-    PriceUpdateBody:
-      type: object
-      title: PriceUpdateBody
-      additionalProperties: false
-      required:
-        - channel
-        - data
-      properties:
-        channel:
-          $ref: '#/components/schemas/DeprecatedPriceChannelPattern'
-        data:
-          $ref: './trading-schemas.json#/definitions/Price'
-
     AssetOraclePricesUpdateBody:
       type: object
       title: AssetOraclePricesUpdateBody
@@ -1163,18 +1067,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdateEnvelope'
         - $ref: '#/components/schemas/AccountBalanceUpdateBody'
-
-    PricesUpdatePayload:
-      title: PricesUpdatePayload
-      allOf:
-        - $ref: '#/components/schemas/BaseUpdateEnvelope'
-        - $ref: '#/components/schemas/PricesUpdateBody'
-
-    PriceUpdatePayload:
-      title: PriceUpdatePayload
-      allOf:
-        - $ref: '#/components/schemas/BaseUpdateEnvelope'
-        - $ref: '#/components/schemas/PriceUpdateBody'
 
     AssetOraclePricesUpdatePayload:
       title: AssetOraclePricesUpdatePayload

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.13
+  version: 3.0.14
   contact:
     name: Reya Network
     url: https://reya.xyz
@@ -235,54 +235,10 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /prices:
-    get:
-      summary: Get all prices
-      description: 'Deprecated: this AMM-era mixed market/collateral price endpoint includes legacy `poolPrice` semantics and will be removed. Use `GET /assetOraclePrices` for asset Stork oracle prices. Use market summary/depth endpoints for market prices.'
-      operationId: getPrices
-      deprecated: true
-      tags:
-        - Market Data
-      responses:
-        '200':
-          description: List of prices
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Price'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /prices/{symbol}:
-    get:
-      summary: Get price by symbol
-      description: 'Deprecated: this AMM-era mixed market/collateral price endpoint includes legacy `poolPrice` semantics and will be removed. Use `GET /assetOraclePrices` for asset Stork oracle prices. Use market summary/depth endpoints for market prices.'
-      operationId: getPrice
-      deprecated: true
-      tags:
-        - Market Data
-      parameters:
-        - $ref: '#/components/parameters/SymbolParam'
-      responses:
-        '200':
-          description: Price information
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Price'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
   /assetOraclePrices:
     get:
       summary: Get asset oracle prices
-      description: Asset Stork oracle prices. This is the replacement for asset-oracle consumers of the deprecated `/prices` endpoint and deliberately omits the AMM-era `poolPrice` field.
+      description: Asset Stork oracle prices. This feed deliberately omits the AMM-era `poolPrice` field.
       operationId: getAssetOraclePrices
       tags:
         - Market Data
@@ -958,9 +914,6 @@ components:
 
     ExecutionBustList:
       $ref: './trading-schemas.json#/definitions/ExecutionBustList'
-
-    Price:
-      $ref: './trading-schemas.json#/definitions/Price'
 
     AssetOraclePrice:
       $ref: './trading-schemas.json#/definitions/AssetOraclePrice'

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -1925,39 +1925,6 @@
       },
       "additionalProperties": true
     },
-    "Price": {
-      "title": "Price",
-      "type": "object",
-      "description": "Deprecated AMM-era mixed market/collateral price shape. Use AssetOraclePrice for asset Stork oracle prices; use market summary/depth endpoints for market prices.",
-      "deprecated": true,
-      "required": [
-        "symbol",
-        "updatedAt",
-        "oraclePrice"
-      ],
-      "properties": {
-        "symbol": {
-          "$ref": "#/definitions/Symbol"
-        },
-        "oraclePrice": {
-          "$ref": "#/definitions/PriceValue",
-          "description": "Price given by the Stork feeds, used both as the peg price for prices on Reya, as well as Mark Prices. The Stork price feed is usually the perp prices across three major CEXs",
-          "example": "43000.00"
-        },
-        "poolPrice": {
-          "$ref": "#/definitions/PriceValue",
-          "description": "The price currently quoted by the AMM for zero volume, from which trades are priced (equivalent to mid price in an order book); a trade of any size will be move this price up or down depending on the direction.",
-          "example": "42999.50"
-        },
-        "updatedAt": {
-          "$ref": "#/definitions/UnsignedInteger",
-          "description": "Last update timestamp (milliseconds)",
-          "example": 1747927089946
-        }
-      },
-      "additionalProperties": true
-    },
-
     "AssetOraclePrice": {
       "title": "AssetOraclePrice",
       "type": "object",


### PR DESCRIPTION
## Summary

- remove deprecated REST `GET /prices` and `GET /prices/{symbol}` from the V2 OpenAPI spec
- remove deprecated read-WS `/v2/prices` and `/v2/prices/{symbol}` channels, operations, messages, and payload schemas from the V2 AsyncAPI spec
- remove the obsolete shared `Price` schema now that `/assetOraclePrices` is the supported oracle-price surface
- bump the V2 spec version to `3.0.14` for the next tag/downstream SDK pins

## Validation

- `jq empty trading-schemas.json`
- YAML parse for `openapi-trading-v2.yaml`, `asyncapi-trading-v2.yaml`, and `asyncapi-exec-v2.yaml`
- `git diff --check`
- `npx --yes @redocly/cli@latest bundle openapi-trading-v2.yaml -o /tmp/reya-openapi-trading-v2-bundled.yaml`
- `npx --yes @asyncapi/cli@latest bundle asyncapi-trading-v2.yaml -o /tmp/reya-asyncapi-trading-v2-bundled.yaml`
- `npx --yes @asyncapi/cli@latest bundle asyncapi-exec-v2.yaml -o /tmp/reya-asyncapi-exec-v2-bundled.yaml`
- `npx --yes @asyncapi/cli@latest validate asyncapi-trading-v2.yaml` (valid; only existing info-level AsyncAPI 3.1.0 recommendation)
- `npx --yes @asyncapi/cli@latest validate asyncapi-exec-v2.yaml` (valid; only existing info-level AsyncAPI 3.1.0 recommendation)

Note: `npx --yes @redocly/cli@latest lint openapi-trading-v2.yaml` still fails on the repo-wide existing `security-defined` rule for all operations, unrelated to this change.
