### PR TITLE
feat(api): add wallet execution sequence pagination

### DIFF
--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -475,6 +475,9 @@ paths:
         - $ref: '#/components/parameters/StartTimeParam'
         - $ref: '#/components/parameters/EndTimeParam'
         - $ref: '#/components/parameters/ExecutionTypeParam'
+        - $ref: '#/components/parameters/PerpExecutionCursorParam'
+        - $ref: '#/components/parameters/PerpExecutionLimitParam'
+        - $ref: '#/components/parameters/PerpExecutionAccountIdsParam'
       responses:
         '200':
           description: List of perpetual executions
@@ -890,6 +893,47 @@ components:
           - ORDER_MATCH
           - LIQUIDATION
         example: LIQUIDATION
+
+    PerpExecutionCursorParam:
+      name: cursor
+      in: query
+      required: false
+      description: >-
+        Selects event-sequence pagination for wallet perp executions. Use
+        `latest` for the first page, then pass the decimal `meta.nextCursor`
+        returned by the previous page. Decimal cursors are exclusive. Omit this
+        parameter to retain timestamp pagination.
+      schema:
+        type: string
+        pattern: '^(latest|[1-9][0-9]*)$'
+      example: latest
+
+    PerpExecutionLimitParam:
+      name: limit
+      in: query
+      required: false
+      description: Page size. Defaults to 100 and cannot exceed 100.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 100
+
+    PerpExecutionAccountIdsParam:
+      name: accountIds
+      in: query
+      required: false
+      description: >-
+        Active perpetual account IDs owned by the path wallet. Omit to select
+        all active perpetual accounts. IDs must be unique.
+      style: form
+      explode: false
+      schema:
+        type: array
+        minItems: 1
+        items:
+          type: integer
+          minimum: 1
 
     ResolutionParam:
       name: resolution

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -2338,6 +2338,11 @@
           "description": "Number of items returned",
           "example": 50
         },
+        "nextCursor": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]*$",
+          "description": "Exclusive decimal event-sequence cursor for the next page. Present only when sequence mode has more rows."
+        },
         "endTime": {
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Timestamp of the last result in response order, in milliseconds. Descending endpoints return newest-first, so this is the oldest returned timestamp and can be used as the next page's endTime boundary.",


### PR DESCRIPTION
## Review packet

- **What and why:** PRO-622 needs an additive, lossless sequence cursor for bounded wallet trade-history export while existing callers retain timestamp pagination by omitting `cursor`. This 49-line contract delta adds `cursor`, `limit`, wallet-owned `accountIds`, and optional `meta.nextCursor` only to wallet `perpExecutions`.
- **Blast radius:** Public OpenAPI request and shared pagination metadata only; no runtime implementation lives here.
- **Verified:** Redocly 2.0.8 bundle passed with no `$id` keys; OpenAPI Generator 7.2.0 produced the expected cursor, limit, account IDs, and next-cursor shapes; generated SDK build and pinned Docker regeneration matched. CodeQL, API spec lint, version bump, and CodeRabbit checks are green. Runtime behavior is covered by offchain #2791 and UI #1458.
- **Human focus:** Confirm that omitted `cursor` preserves timestamp mode, decimal cursors are exclusive, and `accountIds` means unique active perp accounts owned by the path wallet.
- **Not covered:** No runtime implementation. The offchain promotion to main must advance to the tagged specs merge commit.

## Contract

- omit `cursor` to preserve timestamp mode
- use `cursor=latest` for the first sequence page
- use returned `meta.nextCursor` for exclusive later pages
- `limit` accepts 1–100 and defaults to 100
- `accountIds` is a comma-separated unique list

## Rollout

Additive contract first, then backend #2791 and UI #1458. Legacy route removal remains gated in #2792. Do not merge or deploy as part of this agent task.