### PR TITLE
feat: expose 30-day fee tier volume field

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.16
+  version: 3.0.17
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.16
+  version: 3.0.17
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.16
+  version: 3.0.17
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -2192,6 +2192,7 @@
         "tierId",
         "takerFee",
         "makerFee",
+        "volume30d",
         "volume14d",
         "tierType"
       ],
@@ -2210,9 +2211,15 @@
           "description": "Maker fee rate (fee will be qty * makerFee)",
           "example": "0.0002"
         },
+        "volume30d": {
+          "$ref": "#/definitions/UnsignedDecimal",
+          "description": "30-day volume level required for this fee tier to be applied to a wallet",
+          "example": "10000.0"
+        },
         "volume14d": {
           "$ref": "#/definitions/UnsignedDecimal",
-          "description": "14-day volume level required this fee tier to be applied to a wallet",
+          "description": "Deprecated compatibility alias for volume30d",
+          "deprecated": true,
           "example": "10000.0"
         },
         "tierType": {


### PR DESCRIPTION
## Summary

- add canonical `volume30d` to `FeeTierParameters`
- retain required `volume14d` as a deprecated compatibility alias
- allow existing clients to upgrade independently while off-chain moves to a 30-day fee-tier window

## Integration

This is the schema companion for Reya-Labs/reya-off-chain-monorepo#2795. Once merged and tagged, #2795 will pin the release and regenerate `api-v2-sdk`; the server will emit both fields with the same tier-threshold value.

## Validation

- `python3 -m json.tool trading-schemas.json`
- Redocly 2.0.8 OpenAPI bundle
- AsyncAPI CLI 1.7.0 validation for trading and exec specs
