### PR TITLE
breaking: remove 14-day fee tier volume alias

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.17
+  version: 3.0.18
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.17
+  version: 3.0.18
   description: Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
   contact:
     name: Reya Network

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.17
+  version: 3.0.18
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -2193,7 +2193,6 @@
         "takerFee",
         "makerFee",
         "volume30d",
-        "volume14d",
         "tierType"
       ],
       "properties": {
@@ -2214,12 +2213,6 @@
         "volume30d": {
           "$ref": "#/definitions/UnsignedDecimal",
           "description": "30-day volume level required for this fee tier to be applied to a wallet",
-          "example": "10000.0"
-        },
-        "volume14d": {
-          "$ref": "#/definitions/UnsignedDecimal",
-          "description": "Deprecated compatibility alias for volume30d",
-          "deprecated": true,
           "example": "10000.0"
         },
         "tierType": {


### PR DESCRIPTION
## Review packet
- **What & why:** Remove the deprecated `FeeTierParameters.volume14d` alias so `volume30d` is the sole fee-tier threshold field for the coordinated PerpOB devnet breaking cutover. This implements the decision agreed by Tom and Daniel and tracked in [PRO-664](https://linear.app/reya-labs/issue/PRO-664). The version bot consistently advances the OpenAPI and both AsyncAPI documents to `3.0.18`.
- **Blast radius:** Public API schema and every generated client consuming `FeeTierParameters`; consumers still reading or constructing `volume14d` will break and must move to `volume30d`. No runtime producer, persistence, settlement, or smart-contract code is changed in this PR.
- **Verified:** Exact head `be0fee8c24d1747c1e72ba7808449df377244382`: `jq empty trading-schemas.json`; `npx --yes @redocly/cli@2.0.8 bundle openapi-trading-v2.yaml`; `npx --yes @asyncapi/cli@1.7.0 validate asyncapi-trading-v2.yaml`; `npx --yes @asyncapi/cli@1.7.0 validate asyncapi-exec-v2.yaml`; `$id` exclusion check; `git diff --check` — all passed. The exact-head [manual lint workflow](https://github.com/Reya-Labs/reya-api-specs/actions/runs/29826094843) passed, and pinned OpenAPI Generator 7.2.0 produced a required `volume30d` field with no explicit `volume14d`. No test files were touched. One fresh review round found no major or minor findings; no dedicated spec-reviewer exists, so schema/codegen drift was additionally checked manually.
- **Human focus:** Confirm the coordinated breaking removal is intentional, and confirm `3.0.18` will be manually tagged from the merged `feat/perpOB` result before downstream clients update their pins. <!-- author: confirm these are the right spots -->
- **Not covered:** Runtime producer and UI changes are deliberately downstream of the tagged spec: reya-off-chain-monorepo #2795, reya-python-sdk #69, and the prepared UI branch will consume the release in order. Bot-authored synchronize runs are `action_required` and CodeRabbit skips non-default bases, but the exact final head passed the manually dispatched workflow and independent review. The repository has no generated-client CI check; pinned local generation covered this delta. <!-- author: confirm/extend -->

---

## Summary

- remove the deprecated `FeeTierParameters.volume14d` compatibility alias
- make `volume30d` the sole fee-tier threshold field for the coordinated PerpOB devnet cutover

Supersedes the compatibility period in PRO-664 following Tom and Daniel’s approval in Slack.

Tracks PRO-664.
