### PR TITLE
fix(spec): complete perp execution type filter

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.22
+  version: 3.0.23
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.22
+  version: 3.0.23
   description: |
     Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
 

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.22
+  version: 3.0.23
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -873,8 +873,13 @@ components:
       required: false
       description: Filter perp executions by their exact response type. Omit to return executions of all types.
       schema:
-        $ref: './trading-schemas.json#/definitions/ExecutionType'
-      example: LIQUIDATION
+        type: string
+        enum:
+          - ORDER_MATCH
+          - LIQUIDATION
+          - ADL
+          - MARKET_CLOSE
+        example: LIQUIDATION
 
     DepthLimitParam:
       name: limit

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -871,13 +871,10 @@ components:
       name: type
       in: query
       required: false
-      description: Filter perp executions by type. Omit to return executions of all types.
+      description: Filter perp executions by their exact response type. Omit to return executions of all types.
       schema:
-        type: string
-        enum:
-          - ORDER_MATCH
-          - LIQUIDATION
-        example: LIQUIDATION
+        $ref: './trading-schemas.json#/definitions/ExecutionType'
+      example: LIQUIDATION
 
     DepthLimitParam:
       name: limit

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -50,15 +50,18 @@ const executionTypeFilterOperations = [
   '  /wallet/{address}/perpExecutions:',
 ];
 for (const operationHeading of executionTypeFilterOperations) {
-  assert.ok(
-    yamlBlock(openApi, operationHeading).includes(executionTypeParamRef),
-    `${operationHeading.trim()} must expose ExecutionTypeParam`,
+  const pathItem = yamlBlock(openApi, operationHeading);
+  const getOperation = yamlBlock(pathItem, '    get:');
+  assert.equal(
+    getOperation.split(executionTypeParamRef).length - 1,
+    1,
+    `${operationHeading.trim()} GET must expose ExecutionTypeParam exactly once`,
   );
 }
 assert.equal(
   openApi.split(executionTypeParamRef).length - 1,
   executionTypeFilterOperations.length,
-  'ExecutionTypeParam must be used by exactly the market and wallet perp execution operations',
+  'ExecutionTypeParam must not be used outside the market and wallet perp execution GET operations',
 );
 
 for (const expected of [

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -44,7 +44,7 @@ assert.deepEqual(
   'ExecutionTypeParam must stay value-complete with the ExecutionType payload enum',
 );
 const executionTypeParamRefLine =
-  /^(\s*)(?:-\s+)?\$ref:\s*(['"])#\/components\/parameters\/ExecutionTypeParam\2(?:\s+#.*)?\s*$/gm;
+  /^([ ]*)-[ ]+\$ref:[ ]*(['"])#\/components\/parameters\/ExecutionTypeParam\2(?:[ ]+#.*)?[ ]*$/gm;
 const countActiveExecutionTypeParamRefs = (source, expectedIndent) =>
   Array.from(
     source.matchAll(executionTypeParamRefLine),

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -43,6 +43,23 @@ assert.deepEqual(
   tradingSchemas.definitions.ExecutionType.enum,
   'ExecutionTypeParam must stay value-complete with the ExecutionType payload enum',
 );
+const executionTypeParamRef =
+  "$ref: '#/components/parameters/ExecutionTypeParam'";
+const executionTypeFilterOperations = [
+  '  /market/{symbol}/perpExecutions:',
+  '  /wallet/{address}/perpExecutions:',
+];
+for (const operationHeading of executionTypeFilterOperations) {
+  assert.ok(
+    yamlBlock(openApi, operationHeading).includes(executionTypeParamRef),
+    `${operationHeading.trim()} must expose ExecutionTypeParam`,
+  );
+}
+assert.equal(
+  openApi.split(executionTypeParamRef).length - 1,
+  executionTypeFilterOperations.length,
+  'ExecutionTypeParam must be used by exactly the market and wallet perp execution operations',
+);
 
 for (const expected of [
   'host: websocket-devnet.reya-cronos.network',

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -33,6 +33,14 @@ const asyncExecSpecOperation = yamlBlock(openApi, '  /asyncapi-exec-spec.yaml:')
 assert.ok(asyncExecSpecOperation.includes('operationId: getAsyncExecApiSpec'));
 assert.ok(asyncExecSpecOperation.includes('application/yaml:'));
 
+const executionTypeParam = yamlBlock(openApi, '    ExecutionTypeParam:');
+assert.ok(
+  executionTypeParam.includes(
+    "$ref: './trading-schemas.json#/definitions/ExecutionType'",
+  ),
+  'ExecutionTypeParam must reference the canonical ExecutionType payload enum',
+);
+
 for (const expected of [
   'host: websocket-devnet.reya-cronos.network',
   'address: /v2/wallet/{address}/accounts',

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -43,8 +43,10 @@ assert.deepEqual(
   tradingSchemas.definitions.ExecutionType.enum,
   'ExecutionTypeParam must stay value-complete with the ExecutionType payload enum',
 );
-const executionTypeParamRef =
-  "$ref: '#/components/parameters/ExecutionTypeParam'";
+const executionTypeParamRefLine =
+  /^\s*(?:-\s+)?\$ref:\s+'#\/components\/parameters\/ExecutionTypeParam'\s*$/gm;
+const countActiveExecutionTypeParamRefs = (source) =>
+  source.match(executionTypeParamRefLine)?.length ?? 0;
 const executionTypeFilterOperations = [
   '  /market/{symbol}/perpExecutions:',
   '  /wallet/{address}/perpExecutions:',
@@ -52,14 +54,15 @@ const executionTypeFilterOperations = [
 for (const operationHeading of executionTypeFilterOperations) {
   const pathItem = yamlBlock(openApi, operationHeading);
   const getOperation = yamlBlock(pathItem, '    get:');
+  const parameters = yamlBlock(getOperation, '      parameters:');
   assert.equal(
-    getOperation.split(executionTypeParamRef).length - 1,
+    countActiveExecutionTypeParamRefs(parameters),
     1,
-    `${operationHeading.trim()} GET must expose ExecutionTypeParam exactly once`,
+    `${operationHeading.trim()} GET parameters must expose ExecutionTypeParam exactly once`,
   );
 }
 assert.equal(
-  openApi.split(executionTypeParamRef).length - 1,
+  countActiveExecutionTypeParamRefs(openApi),
   executionTypeFilterOperations.length,
   'ExecutionTypeParam must not be used outside the market and wallet perp execution GET operations',
 );

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -44,9 +44,14 @@ assert.deepEqual(
   'ExecutionTypeParam must stay value-complete with the ExecutionType payload enum',
 );
 const executionTypeParamRefLine =
-  /^\s*(?:-\s+)?\$ref:\s+'#\/components\/parameters\/ExecutionTypeParam'\s*$/gm;
-const countActiveExecutionTypeParamRefs = (source) =>
-  source.match(executionTypeParamRefLine)?.length ?? 0;
+  /^(\s*)(?:-\s+)?\$ref:\s*(['"])#\/components\/parameters\/ExecutionTypeParam\2(?:\s+#.*)?\s*$/gm;
+const countActiveExecutionTypeParamRefs = (source, expectedIndent) =>
+  Array.from(
+    source.matchAll(executionTypeParamRefLine),
+    (match) => match[1].length,
+  ).filter(
+    (indent) => expectedIndent === undefined || indent === expectedIndent,
+  ).length;
 const executionTypeFilterOperations = [
   '  /market/{symbol}/perpExecutions:',
   '  /wallet/{address}/perpExecutions:',
@@ -56,7 +61,7 @@ for (const operationHeading of executionTypeFilterOperations) {
   const getOperation = yamlBlock(pathItem, '    get:');
   const parameters = yamlBlock(getOperation, '      parameters:');
   assert.equal(
-    countActiveExecutionTypeParamRefs(parameters),
+    countActiveExecutionTypeParamRefs(parameters, 8),
     1,
     `${operationHeading.trim()} GET parameters must expose ExecutionTypeParam exactly once`,
   );

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -34,11 +34,14 @@ assert.ok(asyncExecSpecOperation.includes('operationId: getAsyncExecApiSpec'));
 assert.ok(asyncExecSpecOperation.includes('application/yaml:'));
 
 const executionTypeParam = yamlBlock(openApi, '    ExecutionTypeParam:');
-assert.ok(
-  executionTypeParam.includes(
-    "$ref: './trading-schemas.json#/definitions/ExecutionType'",
-  ),
-  'ExecutionTypeParam must reference the canonical ExecutionType payload enum',
+const executionTypeParamValues = Array.from(
+  executionTypeParam.matchAll(/^\s+- ([A-Z_]+)$/gm),
+  (match) => match[1],
+);
+assert.deepEqual(
+  executionTypeParamValues,
+  tradingSchemas.definitions.ExecutionType.enum,
+  'ExecutionTypeParam must stay value-complete with the ExecutionType payload enum',
 );
 
 for (const expected of [


### PR DESCRIPTION
## Review packet

- **What & why:** PRO-479's perp-execution response enum contains ORDER_MATCH, LIQUIDATION, ADL, and MARKET_CLOSE, while the query filter advertised only the first two. This makes the shared market/wallet query parameter value-complete, documents exact filtering, and bumps all specs to 3.0.23. A deterministic contract guard keeps the inline parameter enum aligned with the payload enum and proves exactly the two intended GET operations expose it while preserving the generated named filter-enum exports.
- **Blast radius:** Public OpenAPI query surface, downstream SDK generation, and the version/tag consumed by the off-chain stack. A mismatch could document an ignored value, disconnect the parameter from an operation, or break existing generated enum exports.
- **Verified:** Exact head bfbe61dd74d7b9fca88a3c679eb5a9247648a9e1; immutable PR patch SHA-256 87a23c129d774e3673c57899173ed62e4554b7252044e4da4e25d35cba965852. The contract verifier and git diff check pass locally; hosted Lint API Specs and Version Bump checks pass. The mutation matrix accepts valid single/double-quoted refs and trailing comments, while rejecting commented refs, block-scalar/path-level/POST/response displacement, and extra uses. Downstream SDK regeneration from this exact pin is deterministic with no tracked delta. Independent exact-head contract, generic, adversarial, and simplification reviews found no remaining issue. CodeRabbit's full-review finding was fixed and confirmed; its final c2b26748..bfbe61dd incremental review generated no actionable comments.
- **Human focus:** Confirm that keeping the query enum inline is the right compatibility tradeoff for preserving GetMarketPerpExecutionsTypeEnum/GetWalletPerpExecutionsTypeEnum exports, and confirm the 3.0.23 publication/tag target after the parent spec release is merged. <!-- author: confirm these are the right spots -->
- **Not covered:** The reviewed commit is intentionally untagged until human merge/publish. Runtime/database behavior is separately reviewed in reya-off-chain-monorepo#2857; this spec PR alone does not activate filtering. <!-- author: confirm/extend -->

---

Fixes PRO-479

Downstream implementation: https://github.com/Reya-Labs/reya-off-chain-monorepo/pull/2857.

### Decision appendix

- Keep the filter enum inline while asserting parity with the payload enum | low blast radius | direct ref reuse removes public generated named filter-enum exports.
- Scope active refs to each intended GET parameter list and assert the global count | low blast radius | rejects disconnected, commented, path-level, wrong-operation, and extra-use false greens.
- Bump all three specs to 3.0.23 | low blast radius | downstream generation and tagging stay version-consistent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API specifications to version 3.0.23.
  * Clarified execution-type filtering behavior.
  * Added ADL and MARKET_CLOSE as supported execution types.

* **Tests**
  * Added contract checks to verify execution-type consistency and parameter usage across trading APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
