### PR TITLE
fix(spec): correct PaginationMeta example ordering (PRO-173)

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.23
+  version: 3.0.24
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.23
+  version: 3.0.24
   description: |
     Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
 

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.23
+  version: 3.0.24
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -25,6 +25,12 @@ assert.equal(
   'Reduce-only intent. Required only for perp IOC orders. Omit this field for every other order class: perp GTC/GTT, STOP_LOSS/TAKE_PROFIT, and all spot orders. Sending the field, including `false`, for those order classes is rejected with `INPUT_VALIDATION_ERROR`. Omitted values map to `false` in the signed on-chain `OrderDetails.reduceOnly` field.',
 );
 
+const paginationMeta = tradingSchemas.definitions.PaginationMeta.properties;
+assert.ok(
+  paginationMeta.startTime.example > paginationMeta.endTime.example,
+  'PaginationMeta examples must show newest-first ordering',
+);
+
 assert.ok(
   openApi.includes('url: https://api-devnet.reya-cronos.network/v2'),
   'OpenAPI must include the current devnet server',

--- a/trading-schemas.json
+++ b/trading-schemas.json
@@ -2318,12 +2318,12 @@
         "endTime": {
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Timestamp of the last result in response order, in milliseconds. Descending endpoints return newest-first, so this is the oldest returned timestamp and can be used as the next page's endTime boundary.",
-          "example": 1756733679000
+          "example": 1756733579000
         },
         "startTime": {
           "$ref": "#/definitions/UnsignedInteger",
           "description": "Timestamp of the first result in response order, in milliseconds. Descending endpoints return newest-first, so this is the newest returned timestamp.",
-          "example": 1756733579000
+          "example": 1756733679000
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
## Review packet
- **What & why:** PRO-173 fixes the canonical `PaginationMeta` examples so they agree with the documented newest-first response order: `startTime` is now the newer timestamp and `endTime` the older timestamp. A focused contract assertion protects that ordering without freezing the exact example literals. The repository's version workflow advanced all three specs consistently to `3.0.24`.
- **Blast radius:** Public REST/AsyncAPI specification metadata and generated reference examples only; no runtime handler, pagination logic, persistence, settlement, or signing path changes. If wrong, integrators could infer the wrong backward-pagination boundary from rendered API docs.
- **Verified:** `npx --yes node@18 scripts/verify-perpob-contracts.mjs && git diff --check` passed; pinned Redocly 2.0.8 bundle and no-`$id` hard gate passed; pinned AsyncAPI 1.7.0 validation and bundling passed for both specs; current-head GitHub run [31172757676](https://github.com/Reya-Labs/reya-api-specs/actions/runs/31172757676) passed all hard steps. Test-file diff-stat: `scripts/verify-perpob-contracts.mjs | 6 ++++++` (new PaginationMeta ordering guard); no other test files touched. Review round 1 covered generic correctness, API contract drift, and simplification at base `fedcc65` / head `bf735db`; zero majors and zero residual minors.
- **Human focus:** Confirm the intended invariant is `startTime.example > endTime.example` for newest-first pages; confirm the relational assertion is preferable to pinning timestamp literals; confirm the generated `3.0.24` bump is the expected release increment. <!-- author: confirm these are the right spots -->
- **Not covered:** No live pagination request or published GitBook renderer smoke test was run because the implementation is spec/example-only; the bundled schema and regression assertion cover the changed contract locally. Redocly's existing 32 security-definition errors and 3 warnings remain informational in CI and are unchanged by this PR. CodeRabbit skipped the non-default-base auto-review, and the explicit ready-state review command was rate-limited; no CodeRabbit line threads were produced. <!-- author: confirm/extend -->

---

Fixes PRO-173

### Decision appendix

- Base the fix on the active `feat/perpOB` 3.x release line, not `main` · low blast radius · the ticket concerns canonical 3.0.22+ behaviour and `main` remains on 2.3.x.
- Limit the schema edit to swapping the existing example values · low blast radius · the latest ticket ruling says the remaining defect is example ordering only.
