### PR TITLE
docs(api): bound market depth limit contract

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.26
+  version: 3.0.27
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.26
+  version: 3.0.27
   description: |
     Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
 

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.26
+  version: 3.0.27
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -307,10 +307,10 @@ paths:
         Returns an L2 order book snapshot with aggregated price levels for the specified market.
         Supports both spot and perp markets.
 
-        By default the full book is returned. Pass the optional `limit` query parameter to cap the
-        response to the top-N aggregated price levels per side — the `limit` best (highest) bids and
-        the `limit` best (lowest) asks. Omitting `limit` preserves the full-book response (the
-        existing contract is unchanged).
+        By default the top 100 aggregated price levels per side are returned. Pass the optional
+        `limit` query parameter to request between 1 and 1,000 levels per side — the `limit` best
+        (highest) bids and the `limit` best (lowest) asks. Values above 1,000 are clamped to 1,000;
+        other out-of-contract values fall back to the default of 100.
       operationId: getMarketDepth
       tags:
         - Market Data
@@ -887,15 +887,16 @@ components:
       required: false
       description: >-
         Optional cap on the number of aggregated price levels returned per side.
-        The parameter must be an integer >= 1 (as declared by `minimum`); when
-        set to N, the response contains only the top N levels on each side — the
-        N best (highest) bids and the N best (lowest) asks. Omit to receive the
-        full order book (the default). Out-of-contract values (anything below 1)
-        are not rejected — the server safely degrades to returning the full book,
-        the same as omitting the parameter.
+        The default is 100 and the maximum is 1,000. When set to N within the
+        declared range, the response contains the top N levels on each side —
+        the N best (highest) bids and the N best (lowest) asks. Values above the
+        maximum are clamped to 1,000; other out-of-contract values are not
+        rejected and instead fall back to the default of 100.
       schema:
         type: integer
         minimum: 1
+        maximum: 1000
+        default: 100
         example: 10
 
     ResolutionParam:


### PR DESCRIPTION
Aligns the public GET /market/{symbol}/depth contract with Reya-Labs/reya-off-chain-monorepo#2882: omitted and otherwise invalid limits default to 100 levels per side, valid limits are accepted through 1,000, and larger values clamp to 1,000.

Adds schema default 100 and maximum 1000, and removes the stale full-book-default promise.

Validated with the pinned Redocly bundle/no-dollar-id gate and scripts/verify-perpob-contracts.mjs. Redocly lint remains informational with the same repository-wide pre-existing security-defined findings.