### PR TITLE
PRO-942: correct bounded depth boundary wording

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.28
+  version: 3.0.29
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.28
+  version: 3.0.29
   description: |
     Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
 
@@ -145,7 +145,7 @@ channels:
         received `qty`.
       - A `qty` of `0` means delete that `px` from the published view. The level
         may have been fully consumed or may merely have moved outside the
-        1,000-level boundary.
+        100-level boundary.
       - A single `UPDATE` frame may carry multiple changed levels, and levels for
         both `bids` and `asks` may appear together in the same frame. Either side
         may be empty, but every emitted `UPDATE` has at least one changed level.

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.28
+  version: 3.0.29
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -186,7 +186,9 @@ for (const expected of [
 const marketDepthChannel = yamlBlock(infoAsyncApi, '  marketDepth:');
 assert.ok(
   marketDepthChannel.includes('at most the 100 highest') &&
-    marketDepthChannel.includes('exact published top-100 view'),
+    marketDepthChannel.includes('exact published top-100 view') &&
+    marketDepthChannel.includes('100-level boundary') &&
+    !marketDepthChannel.includes('1,000-level boundary'),
   'WebSocket depth must document the fixed 100-level-per-side view',
 );
 for (const message of ['marketDepthSubscribed:', 'marketDepthUpdate:']) {


### PR DESCRIPTION
Correct the remaining AsyncAPI sentence from the old 1,000-level WebSocket boundary to the final fixed top-100 contract. Bumps all aligned specs to 3.0.29 and extends the contract assertion to prevent mixed boundary wording.