### PR TITLE
fix(PRO-942): enforce WebSocket depth schema cap

### DIFF
--- a/asyncapi-exec-v2.yaml
+++ b/asyncapi-exec-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Order Entry WebSocket API v2
-  version: 3.0.29
+  version: 3.0.30
   description: |
     Order-entry WebSocket API for Reya Network's decentralized exchange. This is a request/response surface for placing, modifying, and cancelling orders and managing cancel-on-disconnect over a persistent WebSocket connection — same operations and payload bodies as the REST `/v2` endpoints (`POST /v2/createOrder`, `POST /v2/modifyOrder`, `POST /v2/cancelOrder`, `POST /v2/cancelAll`, `POST /v2/cancelAllAfter`), with lower per-operation overhead.
 

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -989,6 +989,28 @@ components:
         contents:
           $ref: './trading-schemas.json#/definitions/OrderChangesSnapshot'
 
+    WebSocketDepthSnapshot:
+      # Preserve the existing generated TypeScript export name for SDK source compatibility.
+      title: DepthSnapshot
+      description: |
+        The fixed public WebSocket depth snapshot. This narrows the shared REST
+        snapshot maximum from 1,000 to the 100 levels per side published by the
+        WebSocket channel.
+      allOf:
+        - $ref: './trading-schemas.json#/definitions/DepthSnapshot'
+        - type: object
+          properties:
+            bids:
+              type: array
+              maxItems: 100
+              items:
+                $ref: './trading-schemas.json#/definitions/Level'
+            asks:
+              type: array
+              maxItems: 100
+              items:
+                $ref: './trading-schemas.json#/definitions/Level'
+
     MarketDepthSubscribedPayload:
       type: object
       title: MarketDepthSubscribedPayload
@@ -1003,7 +1025,7 @@ components:
         channel:
           $ref: '#/components/schemas/MarketDepthChannelPattern'
         contents:
-          $ref: './trading-schemas.json#/definitions/DepthSnapshot'
+          $ref: '#/components/schemas/WebSocketDepthSnapshot'
 
     MarketPerpExecutionUpdateBody:
       type: object

--- a/asyncapi-trading-v2.yaml
+++ b/asyncapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Reya DEX Trading WebSocket API v2
-  version: 3.0.29
+  version: 3.0.30
   description: |
     Real-time WebSocket API for Reya Network's decentralized exchange. This version provides user-friendly real-time updates with simplified data structures, removing blockchain-specific details and using human-readable formats!
 

--- a/openapi-trading-v2.yaml
+++ b/openapi-trading-v2.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Reya DEX Trading API v2
-  version: 3.0.29
+  version: 3.0.30
   contact:
     name: Reya Network
     url: https://reya.xyz

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -213,9 +213,28 @@ const marketDepthSubscribedPayload = yamlBlock(
 );
 assert.ok(
   marketDepthSubscribedPayload.includes(
+    "$ref: '#/components/schemas/WebSocketDepthSnapshot'",
+  ),
+  'Subscribed depth contents must use the WebSocket-specific snapshot',
+);
+const webSocketDepthSnapshot = yamlBlock(
+  infoAsyncApi,
+  '    WebSocketDepthSnapshot:',
+);
+assert.ok(
+  webSocketDepthSnapshot.includes('title: DepthSnapshot'),
+  'WebSocket depth snapshot must retain the existing SDK export name',
+);
+assert.ok(
+  webSocketDepthSnapshot.includes(
     "$ref: './trading-schemas.json#/definitions/DepthSnapshot'",
   ),
-  'Subscribed depth contents must use DepthSnapshot',
+  'WebSocket depth snapshot must retain the shared snapshot fields',
+);
+assert.equal(
+  (webSocketDepthSnapshot.match(/^\s+maxItems: 100$/gm) ?? []).length,
+  2,
+  'WebSocket depth snapshot must cap both sides at 100 levels',
 );
 const marketDepthUpdateBody = yamlBlock(
   infoAsyncApi,

--- a/scripts/verify-perpob-contracts.mjs
+++ b/scripts/verify-perpob-contracts.mjs
@@ -231,11 +231,16 @@ assert.ok(
   ),
   'WebSocket depth snapshot must retain the shared snapshot fields',
 );
-assert.equal(
-  (webSocketDepthSnapshot.match(/^\s+maxItems: 100$/gm) ?? []).length,
-  2,
-  'WebSocket depth snapshot must cap both sides at 100 levels',
-);
+for (const side of ['bids', 'asks']) {
+  const sideSchema = yamlBlock(
+    webSocketDepthSnapshot,
+    `            ${side}:`,
+  );
+  assert.ok(
+    sideSchema.includes('maxItems: 100'),
+    `WebSocket depth snapshot ${side} must be capped at 100 levels`,
+  );
+}
 const marketDepthUpdateBody = yamlBlock(
   infoAsyncApi,
   '    MarketDepthUpdateBody:',


### PR DESCRIPTION
## Summary
- model the fixed public WebSocket depth snapshot as at most 100 bids and 100 asks
- keep the shared REST snapshot maximum at 1,000 levels per side
- preserve the existing generated `DepthSnapshot` TypeScript export
- add contract assertions for the WebSocket-specific schema

## Validation
- `node scripts/verify-perpob-contracts.mjs`
- `npx --yes @asyncapi/cli@1.7.0 validate asyncapi-trading-v2.yaml`
- off-chain `pnpm generate:sdk` and SDK build
- schema probe: 100 WebSocket levels accepted, 101 rejected; REST still accepts 1,000 and rejects 1,001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket market-depth subscriptions now provide a dedicated depth snapshot format with up to 100 bid and 100 ask levels.
  * Existing depth snapshot naming remains compatible for SDK consumers.
* **Documentation**
  * Updated the AsyncAPI and OpenAPI specifications to version 3.0.30.
  * Refined the WebSocket subscription contract to document and enforce the 100-level depth limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->